### PR TITLE
fix: don't generate unnecessary empty default styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.8.0",
       "license": "MIT",
       "devDependencies": {
-        "@blackbaud/skyux-branding-builder": "5.0.0",
+        "@blackbaud/skyux-branding-builder": "5.0.1",
         "@skyux/dev-infra-private": "github:blackbaud/skyux-dev-infra-private-builds#12.0.0-alpha.21",
         "@tokens-studio/sd-transforms": "2.0.3",
         "@types/fs-extra": "11.0.4",
@@ -114,9 +114,9 @@
       }
     },
     "node_modules/@blackbaud/skyux-branding-builder": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@blackbaud/skyux-branding-builder/-/skyux-branding-builder-5.0.0.tgz",
-      "integrity": "sha512-pzdhVhO1LLYmLjlCpnIslAsg8eHQ7lMPFMQmzVvWuPRIWSZvf4u+EfHIiMQrqQh2qbxxpNzSRFS/oNW07lnokQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@blackbaud/skyux-branding-builder/-/skyux-branding-builder-5.0.1.tgz",
+      "integrity": "sha512-m7hwbbk94t9JYvza+KTEEimK5OD8mw/pihy5H/SskhebrWJDeDpIfQjdPEEMuhLKG3pYUzUkQK2UsogeT7+azA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "publishToNPM": true
   },
   "devDependencies": {
-    "@blackbaud/skyux-branding-builder": "5.0.0",
+    "@blackbaud/skyux-branding-builder": "5.0.1",
     "@skyux/dev-infra-private": "github:blackbaud/skyux-dev-infra-private-builds#12.0.0-alpha.21",
     "@tokens-studio/sd-transforms": "2.0.3",
     "@types/fs-extra": "11.0.4",

--- a/src/tokens/token-config.mts
+++ b/src/tokens/token-config.mts
@@ -7,7 +7,6 @@ export const tokenConfig: TokenConfig = {
       name: 'modern',
       path: 'base-modern.json',
       selector: '.sky-theme-modern',
-      outputPath: 'modern.css',
       referenceTokens: [
         {
           name: 'modern-colors',
@@ -23,7 +22,6 @@ export const tokenConfig: TokenConfig = {
       name: 'base',
       path: 'base-blackbaud.json',
       selector: '.sky-theme-modern.sky-theme-brand-base',
-      outputPath: 'base.css',
       referenceTokens: [
         {
           name: 'base-light',
@@ -79,7 +77,6 @@ export const tokenConfig: TokenConfig = {
       path: 'base-blackbaud.json',
       selector:
         '.sky-theme-modern.sky-theme-brand-base.sky-theme-brand-blackbaud',
-      outputPath: 'blackbaud.css',
       referenceTokens: [
         {
           name: 'bb-light',
@@ -94,10 +91,7 @@ export const tokenConfig: TokenConfig = {
     },
     {
       name: 'default',
-      path: 'default/base.json',
       selector: '.sky-theme-default',
-      outputPath: 'default.css',
-      referenceTokens: [],
       publicTokens: [
         {
           name: 'public-spacing',

--- a/src/tokens/token-config.spec.mts
+++ b/src/tokens/token-config.spec.mts
@@ -6,7 +6,6 @@ test('should have token sets in the correct format', () => {
   expect(tokenSets[0].name).toEqual('modern');
   expect(tokenSets[0].selector).toEqual('.sky-theme-modern');
   expect(tokenSets[0].path).toEqual('base-modern.json');
-  expect(tokenSets[0].outputPath).toEqual('modern.css');
   expect({
     name: 'modern-colors',
     path: 'color/modern.json',
@@ -21,7 +20,6 @@ test('should have token sets in the correct format', () => {
     '.sky-theme-modern.sky-theme-brand-base',
   );
   expect(tokenSets[1].path).toEqual('base-blackbaud.json');
-  expect(tokenSets[1].outputPath).toEqual('base.css');
   expect({
     name: 'base-light',
     path: 'color/base-light.json',
@@ -41,7 +39,6 @@ test('should have token sets in the correct format', () => {
     '.sky-theme-modern.sky-theme-brand-base.sky-theme-brand-blackbaud',
   );
   expect(tokenSets[2].path).toEqual('base-blackbaud.json');
-  expect(tokenSets[2].outputPath).toEqual('blackbaud.css');
   expect({
     name: 'bb-light',
     path: 'color/bb-light.json',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated branding builder dependency to version 5.0.1.

* **Refactor**
  * Simplified token set configuration by removing explicit CSS output paths and the default base token file reference, streamlining how design tokens are resolved and emitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->