### PR TITLE
feat!: update `h5` text color to the deemphasized text color

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,8 +10,8 @@ on:
       - '[0-9]+.x.x'
 
 env:
-  PRERELEASE: 'false'
-  MAJOR_VERSION: 3
+  PRERELEASE: 'true'
+  MAJOR_VERSION: 7
 
 permissions:
   contents: write

--- a/plugins/__snapshots__/build-style-dictionary-plugin.spec.mts.snap
+++ b/plugins/__snapshots__/build-style-dictionary-plugin.spec.mts.snap
@@ -3143,14 +3143,14 @@ exports[`build styles > should generate the correct public API styles 1`] = `
   font-size: var(--sky-theme-font-size-heading-1);
   line-height: var(--sky-theme-font-line_height-heading-1);
   font-family: var(--sky-theme-font-family-heading-1);
-  color: var(--sky-theme-color-text-heading);
+  color: var(--sky-theme-color-text-deemphasized);
 }
 h1 {
   font-weight: var(--sky-theme-font-weight-heading-1);
   font-size: var(--sky-theme-font-size-heading-1);
   line-height: var(--sky-theme-font-line_height-heading-1);
   font-family: var(--sky-theme-font-family-heading-1);
-  color: var(--sky-theme-color-text-heading);
+  color: var(--sky-theme-color-text-deemphasized);
 }
 .sky-theme-font-heading-2 {
   font-weight: var(--sky-theme-font-weight-heading-2);

--- a/plugins/__snapshots__/build-style-dictionary-plugin.spec.mts.snap
+++ b/plugins/__snapshots__/build-style-dictionary-plugin.spec.mts.snap
@@ -3143,14 +3143,14 @@ exports[`build styles > should generate the correct public API styles 1`] = `
   font-size: var(--sky-theme-font-size-heading-1);
   line-height: var(--sky-theme-font-line_height-heading-1);
   font-family: var(--sky-theme-font-family-heading-1);
-  color: var(--sky-theme-color-text-deemphasized);
+  color: var(--sky-theme-color-text-heading);
 }
 h1 {
   font-weight: var(--sky-theme-font-weight-heading-1);
   font-size: var(--sky-theme-font-size-heading-1);
   line-height: var(--sky-theme-font-line_height-heading-1);
   font-family: var(--sky-theme-font-family-heading-1);
-  color: var(--sky-theme-color-text-deemphasized);
+  color: var(--sky-theme-color-text-heading);
 }
 .sky-theme-font-heading-2 {
   font-weight: var(--sky-theme-font-weight-heading-2);
@@ -3199,14 +3199,14 @@ h4 {
   font-size: var(--sky-theme-font-size-heading-5);
   line-height: var(--sky-theme-font-line_height-heading-5);
   font-family: var(--sky-theme-font-family-heading-5);
-  color: var(--sky-theme-color-text-heading);
+  color: var(--sky-theme-color-text-deemphasized);
 }
 h5 {
   font-weight: var(--sky-theme-font-weight-heading-5);
   font-size: var(--sky-theme-font-size-heading-5);
   line-height: var(--sky-theme-font-line_height-heading-5);
   font-family: var(--sky-theme-font-family-heading-5);
-  color: var(--sky-theme-color-text-heading);
+  color: var(--sky-theme-color-text-deemphasized);
 }
 .sky-theme-font-body-m {
   font-weight: var(--sky-theme-font-weight-body-m);

--- a/src/classes/public/typography.json
+++ b/src/classes/public/typography.json
@@ -20,7 +20,7 @@
                 "font-size": "var(--sky-theme-font-size-heading-1)",
                 "line-height": "var(--sky-theme-font-line_height-heading-1)",
                 "font-family": "var(--sky-theme-font-family-heading-1)",
-                "color": "var(--sky-theme-color-text-heading)"
+                "color": "var(--sky-theme-color-text-deemphasized)"
               },
               "deprecatedClassNames": ["sky-font-heading-1"],
               "obsoleteClassNames": ["sky-page-heading"]

--- a/src/classes/public/typography.json
+++ b/src/classes/public/typography.json
@@ -20,7 +20,7 @@
                 "font-size": "var(--sky-theme-font-size-heading-1)",
                 "line-height": "var(--sky-theme-font-line_height-heading-1)",
                 "font-family": "var(--sky-theme-font-family-heading-1)",
-                "color": "var(--sky-theme-color-text-deemphasized)"
+                "color": "var(--sky-theme-color-text-heading)"
               },
               "deprecatedClassNames": ["sky-font-heading-1"],
               "obsoleteClassNames": ["sky-page-heading"]
@@ -79,7 +79,7 @@
                 "font-size": "var(--sky-theme-font-size-heading-5)",
                 "line-height": "var(--sky-theme-font-line_height-heading-5)",
                 "font-family": "var(--sky-theme-font-family-heading-5)",
-                "color": "var(--sky-theme-color-text-heading)"
+                "color": "var(--sky-theme-color-text-deemphasized)"
               },
               "deprecatedClassNames": ["sky-font-heading-5"]
             }


### PR DESCRIPTION
AB#4047800

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated the **Heading 5** text color to use the theme’s **deemphasized** text color.
  - Heading 5 elements now appear with a softer visual emphasis for more consistent typography across the interface.
  - Other typography styles and properties remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->