### PR TITLE
feat: add tokens for styling scrollbars

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "6.1.2",
       "license": "MIT",
       "devDependencies": {
-        "@blackbaud/skyux-branding-builder": "5.0.1",
+        "@blackbaud/skyux-branding-builder": "5.1.0",
         "@skyux/dev-infra-private": "github:blackbaud/skyux-dev-infra-private-builds#12.0.0-alpha.21",
         "@tokens-studio/sd-transforms": "2.0.3",
         "@types/fs-extra": "11.0.4",
@@ -114,9 +114,9 @@
       }
     },
     "node_modules/@blackbaud/skyux-branding-builder": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@blackbaud/skyux-branding-builder/-/skyux-branding-builder-5.0.1.tgz",
-      "integrity": "sha512-m7hwbbk94t9JYvza+KTEEimK5OD8mw/pihy5H/SskhebrWJDeDpIfQjdPEEMuhLKG3pYUzUkQK2UsogeT7+azA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@blackbaud/skyux-branding-builder/-/skyux-branding-builder-5.1.0.tgz",
+      "integrity": "sha512-sK9HEPg1s4ZEV6BY+LL6lurwYEf8rQTfIU+R9wQXYM2d5RLgaZQFdJ98RIIK89XJWu14Pg7iRbHedRr1y13u3w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "publishToNPM": true
   },
   "devDependencies": {
-    "@blackbaud/skyux-branding-builder": "5.0.1",
+    "@blackbaud/skyux-branding-builder": "5.1.0",
     "@skyux/dev-infra-private": "github:blackbaud/skyux-dev-infra-private-builds#12.0.0-alpha.21",
     "@tokens-studio/sd-transforms": "2.0.3",
     "@types/fs-extra": "11.0.4",

--- a/plugins/__snapshots__/build-style-dictionary-plugin.spec.mts.snap
+++ b/plugins/__snapshots__/build-style-dictionary-plugin.spec.mts.snap
@@ -491,6 +491,14 @@ exports[`build styles > should generate the correct base, blackbaud, and modern 
   --bb-shadow-slate-800: 0 5px 5px -3px rgba(33, 44, 63, 0.2), 0 3px 14px 2px rgba(33, 44, 63, 0.12), 0 8px 10px 1px rgba(33, 44, 63, 0.14);
   --bb-shadow-slate-simple-400: 1px 2px 4px 0 rgba(33, 44, 63, 0.5);
 }
+:root:has(body.sky-theme-modern.sky-theme-brand-base) {
+  --bb-color-scrollbar-blackbaud-dark-thumb: #51555c;
+  --bb-color-scrollbar-blackbaud-dark-track: #1c2228;
+  --bb-color-scrollbar-dark-thumb: #51555c;
+  --bb-color-scrollbar-dark-track: #1e2229;
+  --bb-color-scrollbar-thumb: #85888d;
+  --bb-color-scrollbar-track: #ffffff;
+}
 .sky-theme-modern.sky-theme-brand-base {
   --sky-brand-name: var(--bb-brand-name);
   --sky-color-background-action-accent-active: var(--bb-color-blue-100);
@@ -777,6 +785,10 @@ exports[`build styles > should generate the correct base, blackbaud, and modern 
   --sky-elevation-overlay-simple-100: var(--bb-shadow-gray-simple-400);
   --sky-elevation-raised-100: var(--bb-shadow-gray-100);
 }
+:root:has(body.sky-theme-modern.sky-theme-brand-base) {
+  --sky-color-scrollbar-thumb: var(--bb-color-scrollbar-thumb);
+  --sky-color-scrollbar-track: var(--bb-color-scrollbar-track);
+}
 .sky-theme-modern.sky-theme-brand-base.sky-theme-mode-dark {
   --sky-color-background-action-accent-active: var(--bb-color-gray-600);
   --sky-color-background-action-accent-base: var(--bb-color-blue-900);
@@ -1029,6 +1041,10 @@ exports[`build styles > should generate the correct base, blackbaud, and modern 
   --sky-elevation-overlay-400: var(--bb-shadow-gray-2400);
   --sky-elevation-overlay-simple-100: var(--bb-shadow-gray-simple-400);
   --sky-elevation-raised-100: var(--bb-shadow-gray-100);
+}
+:root:has(body.sky-theme-modern.sky-theme-brand-base.sky-theme-mode-dark) {
+  --sky-color-scrollbar-thumb: var(--bb-color-scrollbar-dark-thumb);
+  --sky-color-scrollbar-track: var(--bb-color-scrollbar-dark-track);
 }
 .sky-theme-modern.sky-theme-brand-base {
   --sky-font-style-deemphasized-style: italic;
@@ -2255,6 +2271,14 @@ exports[`build styles > should generate the correct base, blackbaud, and modern 
   --bb-shadow-slate-800: 0 5px 5px -3px rgba(33, 44, 63, 0.2), 0 3px 14px 2px rgba(33, 44, 63, 0.12), 0 8px 10px 1px rgba(33, 44, 63, 0.14);
   --bb-shadow-slate-simple-400: 1px 2px 4px 0 rgba(33, 44, 63, 0.5);
 }
+:root:has(body.sky-theme-modern.sky-theme-brand-base.sky-theme-brand-blackbaud) {
+  --bb-color-scrollbar-blackbaud-dark-thumb: #51555c;
+  --bb-color-scrollbar-blackbaud-dark-track: #1c2228;
+  --bb-color-scrollbar-dark-thumb: #51555c;
+  --bb-color-scrollbar-dark-track: #1e2229;
+  --bb-color-scrollbar-thumb: #85888d;
+  --bb-color-scrollbar-track: #ffffff;
+}
 .sky-theme-modern.sky-theme-brand-base.sky-theme-brand-blackbaud {
   --sky-brand-name: var(--bb-brand-name);
   --sky-color-background-action-accent-base: var(--bb-color-blue-25);
@@ -2525,6 +2549,10 @@ exports[`build styles > should generate the correct base, blackbaud, and modern 
   --sky-elevation-overlay-400: var(--bb-shadow-heavy-black-2400);
   --sky-elevation-overlay-simple-100: var(--bb-shadow-heavy-black-simple-400);
   --sky-elevation-raised-100: var(--bb-shadow-heavy-black-100);
+}
+:root:has(body.sky-theme-modern.sky-theme-brand-base.sky-theme-brand-blackbaud.sky-theme-mode-dark) {
+  --sky-color-scrollbar-thumb: var(--bb-color-scrollbar-blackbaud-dark-thumb);
+  --sky-color-scrollbar-track: var(--bb-color-scrollbar-blackbaud-dark-track);
 }
 "
 `;

--- a/src/tokens/base-blackbaud.json
+++ b/src/tokens/base-blackbaud.json
@@ -1603,6 +1603,54 @@
           "$type": "color",
           "$value": "#141A1F"
         }
+      },
+      "scrollbar": {
+        "track": {
+          "$type": "color",
+          "$value": "#FFFFFF",
+          "$extensions": {
+            "com.blackbaud.developer.sky-token-scope": "root-has-body"
+          }
+        },
+        "thumb": {
+          "$type": "color",
+          "$value": "#85888d",
+          "$extensions": {
+            "com.blackbaud.developer.sky-token-scope": "root-has-body"
+          }
+        }
+      },
+      "scrollbar-dark": {
+        "track": {
+          "$type": "color",
+          "$value": "#1e2229",
+          "$extensions": {
+            "com.blackbaud.developer.sky-token-scope": "root-has-body"
+          }
+        },
+        "thumb": {
+          "$type": "color",
+          "$value": "#51555c",
+          "$extensions": {
+            "com.blackbaud.developer.sky-token-scope": "root-has-body"
+          }
+        }
+      },
+      "scrollbar-blackbaud-dark": {
+        "track": {
+          "$type": "color",
+          "$value": "#1C2228",
+          "$extensions": {
+            "com.blackbaud.developer.sky-token-scope": "root-has-body"
+          }
+        },
+        "thumb": {
+          "$type": "color",
+          "$value": "#51555c",
+          "$extensions": {
+            "com.blackbaud.developer.sky-token-scope": "root-has-body"
+          }
+        }
       }
     },
     "shadow": {

--- a/src/tokens/color/base-dark.json
+++ b/src/tokens/color/base-dark.json
@@ -1065,6 +1065,22 @@
           "$value": "{bb.color.red.900}"
         }
       }
+    },
+    "scrollbar": {
+      "track": {
+        "$type": "color",
+        "$value": "{bb.color.scrollbar-dark.track}",
+        "$extensions": {
+          "com.blackbaud.developer.sky-token-scope": "root-has-body"
+        }
+      },
+      "thumb": {
+        "$type": "color",
+        "$value": "{bb.color.scrollbar-dark.thumb}",
+        "$extensions": {
+          "com.blackbaud.developer.sky-token-scope": "root-has-body"
+        }
+      }
     }
   },
   "elevation": {

--- a/src/tokens/color/base-light.json
+++ b/src/tokens/color/base-light.json
@@ -1061,6 +1061,22 @@
           "$value": "{bb.color.red.200}"
         }
       }
+    },
+    "scrollbar": {
+      "track": {
+        "$type": "color",
+        "$value": "{bb.color.scrollbar.track}",
+        "$extensions": {
+          "com.blackbaud.developer.sky-token-scope": "root-has-body"
+        }
+      },
+      "thumb": {
+        "$type": "color",
+        "$value": "{bb.color.scrollbar.thumb}",
+        "$extensions": {
+          "com.blackbaud.developer.sky-token-scope": "root-has-body"
+        }
+      }
     }
   },
   "elevation": {

--- a/src/tokens/color/bb-dark.json
+++ b/src/tokens/color/bb-dark.json
@@ -835,6 +835,22 @@
           "$value": "{bb.color.gray.900}"
         }
       }
+    },
+    "scrollbar": {
+      "track": {
+        "$type": "color",
+        "$value": "{bb.color.scrollbar-blackbaud-dark.track}",
+        "$extensions": {
+          "com.blackbaud.developer.sky-token-scope": "root-has-body"
+        }
+      },
+      "thumb": {
+        "$type": "color",
+        "$value": "{bb.color.scrollbar-blackbaud-dark.thumb}",
+        "$extensions": {
+          "com.blackbaud.developer.sky-token-scope": "root-has-body"
+        }
+      }
     }
   },
   "elevation": {


### PR DESCRIPTION
## Summary
- Cherry-picked from `scrollbar-tokens` (originally branched off `master` by mistake) onto a new branch based on `6.x.x`, so this can land on the 6.x line instead.
- Adds `sky-color-scrollbar-track`/`sky-color-scrollbar-thumb` reference tokens (root-scoped via `:root:has(body...)`) for base and blackbaud, light and dark.
- Light mode: track matches `sky-color-background-container-base`, thumb uses `bb.color.gray.500`.
- Dark mode (base and blackbaud): track matches `sky-color-background-container-base`, thumb matches `sky-color-background-disabled`.
- Bumps `@blackbaud/skyux-branding-builder` to `5.1.0` for root-scoped-token support.

## Test plan
- [x] `npm run build` — generates correct `:root:has(body...)` blocks for base/blackbaud in light/dark, values verified against source tokens
- [x] `npm test` — 3/3 passing, snapshots regenerated
- [x] `npm run lint` — clean