### PR TITLE
fix: dark mode backdrop fix

### DIFF
--- a/plugins/__snapshots__/build-style-dictionary-plugin.spec.mts.snap
+++ b/plugins/__snapshots__/build-style-dictionary-plugin.spec.mts.snap
@@ -2382,6 +2382,7 @@ exports[`build styles > should generate the correct base, blackbaud, and modern 
   --sky-color-background-action-tertiary-focus: var(--bb-color-transparent);
   --sky-color-background-action-tertiary-hover: var(--bb-color-transparent);
   --sky-color-background-blocking: var(--bb-color-rgba-black-70);
+  --sky-color-background-container-backdrop: var(--bb-color-steel-fusion-1000);
   --sky-color-background-container-base: var(--bb-color-steel-fusion-1100);
   --sky-color-background-container-danger: var(--bb-color-rgba-red-dark-600-35);
   --sky-color-background-container-dimmed: var(--bb-color-steel-fusion-1050);

--- a/src/tokens/color/bb-dark.json
+++ b/src/tokens/color/bb-dark.json
@@ -269,6 +269,10 @@
         "dimmed": {
           "$type": "color",
           "$value": "{bb.color.steel-fusion.1050}"
+        },
+        "backdrop": {
+          "$type": "color",
+          "$value": "{bb.color.steel-fusion.1000}"
         }
       },
       "icon_matte": {


### PR DESCRIPTION
Solve specificity bug for color.container.backdrop in dark mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dark-theme backdrop color token for container backgrounds.
  - The new backdrop color uses the Steel Fusion 1000 palette value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->