### PR TITLE
fix: fix specificity for light mode tokens and validate light and dark mode "base" brand tokens match (#381)

### DIFF
--- a/plugins/__snapshots__/build-style-dictionary-plugin.spec.mts.snap
+++ b/plugins/__snapshots__/build-style-dictionary-plugin.spec.mts.snap
@@ -499,7 +499,7 @@ exports[`build styles > should generate the correct base, blackbaud, and modern 
   --bb-color-scrollbar-bb-dark-thumb: #51555c;
   --bb-color-scrollbar-bb-dark-track: #1c2228;
 }
-.sky-theme-modern.sky-theme-brand-base {
+.sky-theme-modern.sky-theme-brand-base.sky-theme-mode-light {
   --sky-brand-name: var(--bb-brand-name);
   --sky-color-background-action-accent-active: var(--bb-color-blue-100);
   --sky-color-background-action-accent-base: var(--bb-color-white);
@@ -785,11 +785,12 @@ exports[`build styles > should generate the correct base, blackbaud, and modern 
   --sky-elevation-overlay-simple-100: var(--bb-shadow-gray-simple-400);
   --sky-elevation-raised-100: var(--bb-shadow-gray-100);
 }
-:root:has(body.sky-theme-modern.sky-theme-brand-base) {
+:root:has(body.sky-theme-modern.sky-theme-brand-base.sky-theme-mode-light) {
   --sky-color-scrollbar-thumb: var(--bb-color-scrollbar-base-light-thumb);
   --sky-color-scrollbar-track: var(--bb-color-scrollbar-base-light-track);
 }
 .sky-theme-modern.sky-theme-brand-base.sky-theme-mode-dark {
+  --sky-brand-name: var(--bb-brand-name);
   --sky-color-background-action-accent-active: var(--bb-color-gray-600);
   --sky-color-background-action-accent-base: var(--bb-color-blue-900);
   --sky-color-background-action-accent-focus: var(--bb-color-gray-700);
@@ -902,7 +903,6 @@ exports[`build styles > should generate the correct base, blackbaud, and modern 
   --sky-color-border-progress_step: var(--bb-color-gray-600);
   --sky-color-border-selected: var(--bb-color-blue-400);
   --sky-color-border-selected_soft: var(--bb-color-blue-500);
-  --sky-color-border-separator-dark: var(--bb-color-gray-800);
   --sky-color-border-separator-light: var(--bb-color-gray-700);
   --sky-color-border-separator-row: var(--bb-color-gray-800);
   --sky-color-border-success: var(--bb-color-green-400);
@@ -1007,6 +1007,7 @@ exports[`build styles > should generate the correct base, blackbaud, and modern 
   --sky-color-viz-sequence-7: var(--bb-color-teal-400);
   --sky-color-viz-sequence-8: var(--bb-color-teal-300);
   --sky-color-viz-sequence-9: var(--bb-color-teal-200);
+  --sky-image-logo-primary-src: var(--bb-image-logo-primary-src);
   --sky-image-select_icon-base: var(--bb-image-select_icon-base-dark-src);
   --sky-image-select_icon-disabled: var(--bb-image-select_icon-disabled-base-dark-src);
   --sky-opacity-wait: var(--bb-opacity-600);
@@ -1032,7 +1033,39 @@ exports[`build styles > should generate the correct base, blackbaud, and modern 
   --sky-color-border-switch-disabled: var(--sky-color-border-disabled);
   --sky-color-border-switch-selected-disabled: var(--sky-color-border-disabled);
   --sky-color-border-tab-disabled: var(--sky-color-border-disabled);
+  --sky-elevation-action-danger-active: var(--bb-shadow-gray-0);
+  --sky-elevation-action-danger-base: var(--bb-shadow-gray-0);
+  --sky-elevation-action-danger-disabled: var(--bb-shadow-gray-0);
+  --sky-elevation-action-danger-focus: var(--bb-shadow-gray-0);
+  --sky-elevation-action-danger-hover: var(--bb-shadow-gray-0);
+  --sky-elevation-action-input-active: var(--bb-shadow-gray-0);
+  --sky-elevation-action-input-base: var(--bb-shadow-gray-0);
+  --sky-elevation-action-input-disabled: var(--bb-shadow-gray-0);
+  --sky-elevation-action-input-focus: var(--bb-shadow-gray-0);
+  --sky-elevation-action-input-hover: var(--bb-shadow-gray-0);
+  --sky-elevation-action-primary-active: var(--bb-shadow-gray-0);
+  --sky-elevation-action-primary-base: var(--bb-shadow-gray-0);
+  --sky-elevation-action-primary-disabled: var(--bb-shadow-gray-0);
+  --sky-elevation-action-primary-focus: var(--bb-shadow-gray-0);
+  --sky-elevation-action-primary-hover: var(--bb-shadow-gray-0);
+  --sky-elevation-action-secondary-active: var(--bb-shadow-gray-0);
+  --sky-elevation-action-secondary-base: var(--bb-shadow-gray-0);
+  --sky-elevation-action-secondary-disabled: var(--bb-shadow-gray-0);
+  --sky-elevation-action-secondary-focus: var(--bb-shadow-gray-0);
+  --sky-elevation-action-secondary-hover: var(--bb-shadow-gray-0);
+  --sky-elevation-action-tertiary-active: var(--bb-shadow-gray-0);
+  --sky-elevation-action-tertiary-base: var(--bb-shadow-gray-0);
+  --sky-elevation-action-tertiary-disabled: var(--bb-shadow-gray-0);
+  --sky-elevation-action-tertiary-focus: var(--bb-shadow-gray-0);
+  --sky-elevation-action-tertiary-hover: var(--bb-shadow-gray-0);
+  --sky-elevation-action-toolbar-active: var(--bb-shadow-gray-0);
+  --sky-elevation-action-toolbar-base: var(--bb-shadow-gray-0);
+  --sky-elevation-action-toolbar-disabled: var(--bb-shadow-gray-0);
+  --sky-elevation-action-toolbar-focus: var(--bb-shadow-gray-0);
+  --sky-elevation-action-toolbar-hover: var(--bb-shadow-gray-0);
   --sky-elevation-focus: var(--bb-shadow-gray-200);
+  --sky-elevation-input-base: var(--bb-shadow-gray-0);
+  --sky-elevation-input-disabled: var(--bb-shadow-gray-0);
   --sky-elevation-none: var(--bb-shadow-gray-0);
   --sky-elevation-overflow: var(--bb-shadow-gray-200);
   --sky-elevation-overlay-100: var(--bb-shadow-gray-400);
@@ -2279,7 +2312,7 @@ exports[`build styles > should generate the correct base, blackbaud, and modern 
   --bb-color-scrollbar-bb-dark-thumb: #51555c;
   --bb-color-scrollbar-bb-dark-track: #1c2228;
 }
-.sky-theme-modern.sky-theme-brand-base.sky-theme-brand-blackbaud {
+.sky-theme-modern.sky-theme-brand-base.sky-theme-brand-blackbaud.sky-theme-mode-light {
   --sky-brand-name: var(--bb-brand-name);
   --sky-color-background-action-accent-base: var(--bb-color-blue-25);
   --sky-color-background-container-backdrop: var(--bb-color-slate-200);
@@ -2477,7 +2510,6 @@ exports[`build styles > should generate the correct base, blackbaud, and modern 
   --sky-color-border-progress_step: var(--bb-color-gray-600);
   --sky-color-border-selected: var(--bb-color-blue-400);
   --sky-color-border-selected_soft: var(--bb-color-blue-600);
-  --sky-color-border-separator-dark: var(--bb-color-gray-800);
   --sky-color-border-separator-light: var(--bb-color-gray-700);
   --sky-color-border-separator-row: var(--bb-color-gray-800);
   --sky-color-border-success: var(--bb-color-green-500);

--- a/src/tokens/color/base-dark.json
+++ b/src/tokens/color/base-dark.json
@@ -704,10 +704,6 @@
         }
       },
       "separator": {
-        "dark": {
-          "$type": "color",
-          "$value": "{bb.color.gray.800}"
-        },
         "light": {
           "$type": "color",
           "$value": "{bb.color.gray.700}"
@@ -1125,6 +1121,150 @@
           "$value": "{bb.shadow.gray.simple.400}"
         }
       }
+    },
+    "action": {
+      "primary": {
+        "base": {
+          "$type": "boxShadow",
+          "$value": "{bb.shadow.gray.0}"
+        },
+        "hover": {
+          "$type": "boxShadow",
+          "$value": "{bb.shadow.gray.0}"
+        },
+        "active": {
+          "$type": "boxShadow",
+          "$value": "{bb.shadow.gray.0}"
+        },
+        "focus": {
+          "$type": "boxShadow",
+          "$value": "{bb.shadow.gray.0}"
+        },
+        "disabled": {
+          "$type": "boxShadow",
+          "$value": "{bb.shadow.gray.0}"
+        }
+      },
+      "secondary": {
+        "base": {
+          "$type": "boxShadow",
+          "$value": "{bb.shadow.gray.0}"
+        },
+        "hover": {
+          "$type": "boxShadow",
+          "$value": "{bb.shadow.gray.0}"
+        },
+        "active": {
+          "$type": "boxShadow",
+          "$value": "{bb.shadow.gray.0}"
+        },
+        "focus": {
+          "$type": "boxShadow",
+          "$value": "{bb.shadow.gray.0}"
+        },
+        "disabled": {
+          "$type": "boxShadow",
+          "$value": "{bb.shadow.gray.0}"
+        }
+      },
+      "tertiary": {
+        "base": {
+          "$type": "boxShadow",
+          "$value": "{bb.shadow.gray.0}"
+        },
+        "hover": {
+          "$type": "boxShadow",
+          "$value": "{bb.shadow.gray.0}"
+        },
+        "active": {
+          "$type": "boxShadow",
+          "$value": "{bb.shadow.gray.0}"
+        },
+        "focus": {
+          "$type": "boxShadow",
+          "$value": "{bb.shadow.gray.0}"
+        },
+        "disabled": {
+          "$type": "boxShadow",
+          "$value": "{bb.shadow.gray.0}"
+        }
+      },
+      "danger": {
+        "base": {
+          "$type": "boxShadow",
+          "$value": "{bb.shadow.gray.0}"
+        },
+        "hover": {
+          "$type": "boxShadow",
+          "$value": "{bb.shadow.gray.0}"
+        },
+        "active": {
+          "$type": "boxShadow",
+          "$value": "{bb.shadow.gray.0}"
+        },
+        "focus": {
+          "$type": "boxShadow",
+          "$value": "{bb.shadow.gray.0}"
+        },
+        "disabled": {
+          "$type": "boxShadow",
+          "$value": "{bb.shadow.gray.0}"
+        }
+      },
+      "input": {
+        "base": {
+          "$type": "boxShadow",
+          "$value": "{bb.shadow.gray.0}"
+        },
+        "hover": {
+          "$type": "boxShadow",
+          "$value": "{bb.shadow.gray.0}"
+        },
+        "active": {
+          "$type": "boxShadow",
+          "$value": "{bb.shadow.gray.0}"
+        },
+        "focus": {
+          "$type": "boxShadow",
+          "$value": "{bb.shadow.gray.0}"
+        },
+        "disabled": {
+          "$type": "boxShadow",
+          "$value": "{bb.shadow.gray.0}"
+        }
+      },
+      "toolbar": {
+        "base": {
+          "$type": "boxShadow",
+          "$value": "{bb.shadow.gray.0}"
+        },
+        "hover": {
+          "$type": "boxShadow",
+          "$value": "{bb.shadow.gray.0}"
+        },
+        "active": {
+          "$type": "boxShadow",
+          "$value": "{bb.shadow.gray.0}"
+        },
+        "focus": {
+          "$type": "boxShadow",
+          "$value": "{bb.shadow.gray.0}"
+        },
+        "disabled": {
+          "$type": "boxShadow",
+          "$value": "{bb.shadow.gray.0}"
+        }
+      }
+    },
+    "input": {
+      "base": {
+        "$type": "boxShadow",
+        "$value": "{bb.shadow.gray.0}"
+      },
+      "disabled": {
+        "$type": "boxShadow",
+        "$value": "{bb.shadow.gray.0}"
+      }
     }
   },
   "opacity": {
@@ -1134,6 +1274,14 @@
     }
   },
   "image": {
+    "logo": {
+      "primary": {
+        "src": {
+          "$type": "other",
+          "$value": "{bb.image.logo.primary.src}"
+        }
+      }
+    },
     "select_icon": {
       "base": {
         "$type": "other",
@@ -1143,6 +1291,12 @@
         "$type": "other",
         "$value": "{bb.image.select_icon.disabled.base.dark.src}"
       }
+    }
+  },
+  "brand": {
+    "name": {
+      "$type": "other",
+      "$value": "{bb.brand.name}"
     }
   }
 }

--- a/src/tokens/color/bb-dark.json
+++ b/src/tokens/color/bb-dark.json
@@ -684,10 +684,6 @@
         }
       },
       "separator": {
-        "dark": {
-          "$type": "color",
-          "$value": "{bb.color.gray.800}"
-        },
         "light": {
           "$type": "color",
           "$value": "{bb.color.gray.700}"

--- a/src/tokens/color/color-validation.spec.mts
+++ b/src/tokens/color/color-validation.spec.mts
@@ -1,0 +1,80 @@
+import { expect, test } from 'vitest';
+
+import baseDark from './base-dark.json';
+import baseLight from './base-light.json';
+
+/**
+ * A token node is a leaf once it has a "$value" property. Everything else is
+ * a nested group to recurse into.
+ */
+function isTokenNode(value: unknown): value is { $value: unknown } {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    Object.prototype.hasOwnProperty.call(value, '$value')
+  );
+}
+
+/**
+ * Flattens a token tree into a list of dot-delimited token paths, e.g.
+ * `color.text.default`, so token sets can be diffed by name alone.
+ */
+function getTokenPaths(
+  tokens: Record<string, unknown>,
+  prefix: string[] = [],
+): string[] {
+  return Object.entries(tokens).flatMap(([key, value]) => {
+    const path = [...prefix, key];
+
+    if (isTokenNode(value)) {
+      return [path.join('.')];
+    }
+
+    return getTokenPaths(value as Record<string, unknown>, path);
+  });
+}
+
+/** Returns the token paths present in `sourcePaths` but absent from `targetPaths`. */
+function getMissingTokenPaths(
+  sourcePaths: string[],
+  targetPaths: string[],
+): string[] {
+  const targetSet = new Set(targetPaths);
+
+  return sourcePaths.filter((tokenPath) => !targetSet.has(tokenPath));
+}
+
+function formatMissingTokensMessage(
+  missingTokenPaths: string[],
+  sourceFile: string,
+  targetFile: string,
+): string {
+  return `The following tokens are defined in ${sourceFile} but missing from ${targetFile}:\n${missingTokenPaths
+    .map((tokenPath) => `  - ${tokenPath}`)
+    .join('\n')}`;
+}
+
+test('should have the same "base" reference tokens for light and dark modes', () => {
+  const lightTokenPaths = getTokenPaths(baseLight);
+  const darkTokenPaths = getTokenPaths(baseDark);
+
+  const missingFromDark = getMissingTokenPaths(lightTokenPaths, darkTokenPaths);
+  const missingFromLight = getMissingTokenPaths(darkTokenPaths, lightTokenPaths);
+
+  const failureMessages = [
+    missingFromDark.length > 0 &&
+      formatMissingTokensMessage(
+        missingFromDark,
+        'base-light.json',
+        'base-dark.json',
+      ),
+    missingFromLight.length > 0 &&
+      formatMissingTokensMessage(
+        missingFromLight,
+        'base-dark.json',
+        'base-light.json',
+      ),
+  ].filter((message) => typeof message === 'string');
+
+  expect(failureMessages, failureMessages.join('\n\n')).toEqual([]);
+});

--- a/src/tokens/token-config.mts
+++ b/src/tokens/token-config.mts
@@ -10,6 +10,7 @@ export const tokenConfig: TokenConfig = {
       referenceTokens: [
         {
           name: 'base-light',
+          selector: '.sky-theme-mode-light',
           path: 'color/base-light.json',
         },
         {
@@ -65,6 +66,7 @@ export const tokenConfig: TokenConfig = {
       referenceTokens: [
         {
           name: 'bb-light',
+          selector: '.sky-theme-mode-light',
           path: 'color/bb-light.json',
         },
         {

--- a/src/tokens/token-config.spec.mts
+++ b/src/tokens/token-config.spec.mts
@@ -12,6 +12,7 @@ test('should have token sets in the correct format', () => {
   /* eslint-disable @typescript-eslint/no-non-null-assertion */
   expect({
     name: 'base-light',
+    selector: '.sky-theme-mode-light',
     path: 'color/base-light.json',
   }).toBeOneOf(tokenSets[0].referenceTokens!);
   expect({
@@ -31,6 +32,7 @@ test('should have token sets in the correct format', () => {
   expect(tokenSets[1].path).toEqual('base-blackbaud.json');
   expect({
     name: 'bb-light',
+    selector: '.sky-theme-mode-light',
     path: 'color/bb-light.json',
   }).toBeOneOf(tokenSets[1].referenceTokens!);
   expect({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added design tokens for action and input elevation states.
  * Added tokens for the primary logo image and brand name.
  * Added light-theme selectors for light reference token sets.

* **Bug Fixes**
  * Removed the deprecated dark separator border token.

* **Tests**
  * Added validation to ensure light and dark themes contain matching token paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->