### PR TITLE
feat: add tokens for container overlay border styles (#384)

### DIFF
--- a/plugins/__snapshots__/build-style-dictionary-plugin.spec.mts.snap
+++ b/plugins/__snapshots__/build-style-dictionary-plugin.spec.mts.snap
@@ -65,6 +65,7 @@ exports[`build styles > should generate the correct base, blackbaud, and modern 
   --bb-border-radius-pill: 999rem;
   --bb-border-radius-round: 50%;
   --bb-border-style-dotted: dotted;
+  --bb-border-style-none: none;
   --bb-border-style-solid: solid;
   --bb-brand-name: 'Blackbaud';
   --bb-color-black: #000000;
@@ -1109,6 +1110,7 @@ exports[`build styles > should generate the correct base, blackbaud, and modern 
   --sky-border-radius-thumb: var(--bb-border-radius-round);
   --sky-border-radius-xs: var(--bb-border-radius-012);
   --sky-border-style-accent: var(--bb-border-style-solid);
+  --sky-border-style-container-overlay: var(--bb-border-style-none);
   --sky-border-style-divider: var(--bb-border-style-solid);
   --sky-border-style-elevation: var(--bb-border-style-solid);
   --sky-border-style-separator-dark: var(--bb-border-style-solid);
@@ -1812,6 +1814,9 @@ exports[`build styles > should generate the correct base, blackbaud, and modern 
   --sky-type-heading-1: var(--sky-font-style-heading-1) var(--sky-font-size-heading-1)/36 'var(--bb-font-blkb_sans-name)';
   --sky-type-input-val: var(--sky-font-style-body-s) var(--sky-font-size-input-val)/20 'var(--bb-font-blkb_sans-name)';
 }
+.sky-theme-modern.sky-theme-brand-base.sky-theme-mode-dark {
+  --sky-border-style-container-overlay: var(--bb-border-style-solid);
+}
 "
 `;
 
@@ -1878,6 +1883,7 @@ exports[`build styles > should generate the correct base, blackbaud, and modern 
   --bb-border-radius-pill: 999rem;
   --bb-border-radius-round: 50%;
   --bb-border-style-dotted: dotted;
+  --bb-border-style-none: none;
   --bb-border-style-solid: solid;
   --bb-brand-name: 'Blackbaud';
   --bb-color-black: #000000;

--- a/src/tokens/base-blackbaud.json
+++ b/src/tokens/base-blackbaud.json
@@ -302,6 +302,10 @@
         "dotted": {
           "$type": "other",
           "$value": "dotted"
+        },
+        "none": {
+          "$type": "other",
+          "$value": "none"
         }
       }
     },

--- a/src/tokens/layout/base-productive-dark.json
+++ b/src/tokens/layout/base-productive-dark.json
@@ -1,0 +1,12 @@
+{
+  "border": {
+    "style": {
+      "container": {
+        "overlay": {
+          "$type": "other",
+          "$value": "{bb.border.style.solid}"
+        }
+      }
+    }
+  }
+}

--- a/src/tokens/layout/base-productive.json
+++ b/src/tokens/layout/base-productive.json
@@ -1280,6 +1280,12 @@
           "$type": "other",
           "$value": "{bb.border.style.solid}"
         }
+      },
+      "container": {
+        "overlay": {
+          "$type": "other",
+          "$value": "{bb.border.style.none}"
+        }
       }
     }
   },

--- a/src/tokens/token-config.mts
+++ b/src/tokens/token-config.mts
@@ -22,6 +22,11 @@ export const tokenConfig: TokenConfig = {
           name: 'base-productive',
           path: 'layout/base-productive.json',
         },
+        {
+          name: 'base-productive-dark',
+          selector: '.sky-theme-mode-dark',
+          path: 'layout/base-productive-dark.json',
+        },
       ],
       publicTokens: [
         {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added `bb.border.style.none`.
- Added `border.style.container.overlay` with `none` for the productive theme.
- Added the dark productive theme token set with a `solid` container overlay border.
- Updated token configuration to include `base-productive-dark`.

The `.coderabbit.yaml` file from the CodeRabbit repository in ADO is used: https://dev.azure.com/blackbaud/Products/_git/coderabbit

<!-- end of auto-generated comment: release notes by coderabbit.ai -->