### PR TITLE
chore: fix cherry pick workflow

### DIFF
--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -7,7 +7,7 @@ on:
       - '[0-9]+.x.x'
 
 env:
-  TARGET_BRANCH: main
+  TARGET_BRANCH: master
   FROM_BRANCH: ${{ github.event.pull_request.base.ref }}
 
 jobs:

--- a/.skyuxdev.json
+++ b/.skyuxdev.json
@@ -1,0 +1,3 @@
+{
+  "baseBranch": "master"
+}


### PR DESCRIPTION
## Summary
- The cherry-pick workflow has been failing since it was introduced — every run errors out before it can push a cherry-pick branch or open a PR ([example failed run](https://github.com/blackbaud/skyux-design-tokens/actions/runs/32158699852/job/95782069952)).
- Root cause: `npx skyux-dev cherry-pick` requires a `.skyuxdev.json` config file at the repo root, but this repo never had one, so the command fails immediately with `A configuration file named '.skyuxdev.json' was expected but not found.`
- Fixed by adding `.skyuxdev.json` with `baseBranch: master`, matching the pattern used by [skyux-icons](https://github.com/blackbaud/skyux-icons/blob/master/.skyuxdev.json), whose cherry-pick workflow runs successfully.

## Test plan
- [x] Ran `npx skyux-dev cherry-pick --help` locally and confirmed the config-file error no longer occurs.
- [ ] Merge a PR into a `*.x.x` branch and confirm the cherry-pick workflow succeeds and opens a PR against `master`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added `.skyuxdev.json` with `baseBranch` set to `master`.
- Updated the cherry-pick workflow to target `master`.
- Fixed the `npx skyux-dev cherry-pick` configuration error.
- The `.coderabbit.yaml` file from the CodeRabbit repository in ADO is used: https://dev.azure.com/blackbaud/Products/_git/coderabbit
<!-- end of auto-generated comment: release notes by coderabbit.ai -->