### PR TITLE
chore: fix cherry pick workflow

### DIFF
--- a/.skyuxdev.json
+++ b/.skyuxdev.json
@@ -1,0 +1,3 @@
+{
+  "baseBranch": "master"
+}


### PR DESCRIPTION
## Summary
- Supersedes #389, which incorrectly targeted `master`.
- The cherry-pick workflow has been failing since it was introduced ([example failed run](https://github.com/blackbaud/skyux-design-tokens/actions/runs/32158699852/job/95782069952)): `npx skyux-dev cherry-pick` requires a `.skyuxdev.json` config file, but the job's `actions/checkout` step always checks out `master` (`ref: ${{ env.TARGET_BRANCH }}`, hardcoded to `master`), and `master` never had this file, so the command fails immediately with `A configuration file named '.skyuxdev.json' was expected but not found.`
- Adds `.skyuxdev.json` with `baseBranch: master`, matching the pattern used by [skyux-icons](https://github.com/blackbaud/skyux-icons/blob/master/.skyuxdev.json), whose cherry-pick workflow runs successfully.
- Targeting `6.x.x` (the active release branch, matching this repo's normal PR-then-cherry-pick convention) rather than `master` directly. Note: once this merges, the cherry-pick job it triggers may itself still fail once, since `master` won't yet have `.skyuxdev.json` at that point — if so, a manual follow-up PR adding the same `.skyuxdev.json` to `master` will be needed to fully unblock the bot.

## Test plan
- [x] Ran `npx skyux-dev cherry-pick --help` locally and confirmed the config-file error no longer occurs.
- [ ] Merge and confirm whether the triggered cherry-pick run succeeds in creating a PR against `master`; if not, manually port `.skyuxdev.json` to `master`.