### PR TITLE
chore: fix cherry pick workflow

### DIFF
--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -7,7 +7,7 @@ on:
       - '[0-9]+.x.x'
 
 env:
-  TARGET_BRANCH: main
+  TARGET_BRANCH: master
   FROM_BRANCH: ${{ github.event.pull_request.base.ref }}
 
 jobs:

--- a/.skyuxdev.json
+++ b/.skyuxdev.json
@@ -1,0 +1,3 @@
+{
+  "baseBranch": "master"
+}


### PR DESCRIPTION
## Summary
- Follow-up to #390. That PR added `.skyuxdev.json` on `6.x.x`, but the cherry-pick job's `actions/checkout` step is hardcoded to `master` (`ref: ${{ env.TARGET_BRANCH }}`), so `master` still lacked the file — causing the exact same failure to recur on the run #390 itself triggered: [run 32165498798](https://github.com/blackbaud/skyux-design-tokens/actions/runs/32165498798/job/95804006494).
- This PR adds `.skyuxdev.json` (`baseBranch: master`) directly to `master`, and also fixes the stale `TARGET_BRANCH: main` in `cherry-pick.yml` on `master` so any future release branch cut from `master` (e.g. `7.x.x`) inherits the correct value.

## Test plan
- [x] Ran `npx skyux-dev cherry-pick --help` locally and confirmed no config-file error.
- [ ] Merge a PR into a `*.x.x` branch and confirm the cherry-pick workflow succeeds end-to-end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added `.skyuxdev.json` with `baseBranch: master`.
- Changed `TARGET_BRANCH` in `cherry-pick.yml` from `main` to `master`.
- Local help-command validation passed.
- End-to-end workflow validation remains pending.

The `.coderabbit.yaml` file from the CodeRabbit repository in ADO is being used: https://dev.azure.com/blackbaud/Products/_git/coderabbit

<!-- end of auto-generated comment: release notes by coderabbit.ai -->