### PR TITLE
chore: include failure title in cherry-pick Slack notification

### DIFF
--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -151,4 +151,3 @@ jobs:
           SLACK_CHANNEL: C01GY7ZP4HM
           SLACK_COLOR: 'fail'
           SLACK_FOOTER: 'Blackbaud Sky Build User'
-          MSG_MINIMAL: 'true'


### PR DESCRIPTION
## Summary
- The cherry-pick workflow's failure Slack notification was showing only a bare run URL, with no indication of what actually failed (see attached screenshot in [discussion](#390)).
- Root cause: `MSG_MINIMAL: 'true'` tells [`rtCamp/action-slack-notify`](https://github.com/rtCamp/action-slack-notify/blob/master/main.go) to build the payload with only the `SLACK_MESSAGE` text field, dropping `SLACK_TITLE` (and all other context fields) entirely — even though the step already sets a descriptive `SLACK_TITLE` (`Cherry-pick failed for "<PR title> (#<number>)"`).
- Fix: remove `MSG_MINIMAL: 'true'` so the title is included in the notification, along with ref/event/commit context.

## Test plan
- [ ] Trigger a failing cherry-pick and confirm the Slack message now includes the failure title, not just the bare link.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Removed `MSG_MINIMAL: 'true'` from the cherry-pick failure Slack notification.
- Restored the failure title, ref, event, and commit context.

The `.coderabbit.yaml` file from the CodeRabbit repository in ADO is used: https://dev.azure.com/blackbaud/Products/_git/coderabbit

<!-- end of auto-generated comment: release notes by coderabbit.ai -->