### PR TITLE
chore: include failure title in cherry-pick Slack notification (#392)

### DIFF
--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -151,4 +151,3 @@ jobs:
           SLACK_CHANNEL: C01GY7ZP4HM
           SLACK_COLOR: 'fail'
           SLACK_FOOTER: 'Blackbaud Sky Build User'
-          MSG_MINIMAL: 'true'


### PR DESCRIPTION
:cherries: Cherry picked from #392 [chore: include failure title in cherry-pick Slack notification](https://github.com/blackbaud/skyux-design-tokens/pull/392)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Removed `MSG_MINIMAL: 'true'` from the cherry-pick failure Slack notification workflow.
- Slack notifications can now include the failure title.

The `.coderabbit.yaml` file from the CodeRabbit repository in ADO is used: https://dev.azure.com/blackbaud/Products/_git/coderabbit

<!-- end of auto-generated comment: release notes by coderabbit.ai -->