### PR TITLE
fix: update blocking wait background in dark mode (#380)

### DIFF
--- a/plugins/__snapshots__/build-style-dictionary-plugin.spec.mts.snap
+++ b/plugins/__snapshots__/build-style-dictionary-plugin.spec.mts.snap
@@ -245,6 +245,7 @@ exports[`build styles > should generate the correct base, blackbaud, and modern 
   --bb-color-rgba-red-dark-600-50: rgba(181, 47, 50, 0.5);
   --bb-color-rgba-sky-600-40: rgba(0, 207, 255, 0.4);
   --bb-color-rgba-steel-fusion-100-5: rgba(243, 246, 249, 0.05);
+  --bb-color-rgba-steel-fusion-1100-70: rgba(28, 34, 40, 0.7);
   --bb-color-rgba-white-5: rgba(255, 255, 255, 0.05);
   --bb-color-rgba-white-70: rgba(255, 255, 255, 0.7);
   --bb-color-rgba-yellow-dark-600-25: rgba(162, 81, 0, 0.25);
@@ -816,7 +817,7 @@ exports[`build styles > should generate the correct base, blackbaud, and modern 
   --sky-color-background-action-tertiary-base: var(--bb-color-transparent);
   --sky-color-background-action-tertiary-focus: var(--bb-color-transparent);
   --sky-color-background-action-tertiary-hover: var(--bb-color-transparent);
-  --sky-color-background-blocking: var(--bb-color-rgba-black-70);
+  --sky-color-background-blocking: var(--bb-color-rgba-steel-fusion-1100-70);
   --sky-color-background-container-backdrop: var(--bb-color-gray-900);
   --sky-color-background-container-base: var(--bb-color-gray-1000);
   --sky-color-background-container-danger: var(--bb-color-red-800);
@@ -2063,6 +2064,7 @@ exports[`build styles > should generate the correct base, blackbaud, and modern 
   --bb-color-rgba-red-dark-600-50: rgba(181, 47, 50, 0.5);
   --bb-color-rgba-sky-600-40: rgba(0, 207, 255, 0.4);
   --bb-color-rgba-steel-fusion-100-5: rgba(243, 246, 249, 0.05);
+  --bb-color-rgba-steel-fusion-1100-70: rgba(28, 34, 40, 0.7);
   --bb-color-rgba-white-5: rgba(255, 255, 255, 0.05);
   --bb-color-rgba-white-70: rgba(255, 255, 255, 0.7);
   --bb-color-rgba-yellow-dark-600-25: rgba(162, 81, 0, 0.25);
@@ -2420,7 +2422,7 @@ exports[`build styles > should generate the correct base, blackbaud, and modern 
   --sky-color-background-action-tertiary-disabled: var(--bb-color-gray-700);
   --sky-color-background-action-tertiary-focus: var(--bb-color-transparent);
   --sky-color-background-action-tertiary-hover: var(--bb-color-transparent);
-  --sky-color-background-blocking: var(--bb-color-rgba-black-70);
+  --sky-color-background-blocking: var(--bb-color-rgba-steel-fusion-1100-70);
   --sky-color-background-container-backdrop: var(--bb-color-steel-fusion-1000);
   --sky-color-background-container-base: var(--bb-color-steel-fusion-1100);
   --sky-color-background-container-danger: var(--bb-color-rgba-red-dark-600-35);

--- a/src/tokens/$metadata.json
+++ b/src/tokens/$metadata.json
@@ -6,6 +6,7 @@
     "color/bb-light",
     "color/bb-dark",
     "layout/base-productive",
+    "layout/bb-productive",
     "public/borders",
     "public/colors",
     "public/elevation",

--- a/src/tokens/base-blackbaud.json
+++ b/src/tokens/base-blackbaud.json
@@ -467,6 +467,12 @@
               "$type": "color",
               "$value": "rgba(243, 246, 249,.05)"
             }
+          },
+          "1100": {
+            "70": {
+              "$type": "color",
+              "$value": "rgba(28, 34, 40,.7)"
+            }
           }
         },
         "black": {
@@ -1612,52 +1618,52 @@
         "base": {
           "light": {
             "track": {
-              "$type": "color",
-              "$value": "#FFFFFF",
               "$extensions": {
                 "com.blackbaud.developer.sky-token-scope": "root-has-body"
-              }
+              },
+              "$type": "color",
+              "$value": "#FFFFFF"
             },
             "thumb": {
-              "$type": "color",
-              "$value": "#85888d",
               "$extensions": {
                 "com.blackbaud.developer.sky-token-scope": "root-has-body"
-              }
+              },
+              "$type": "color",
+              "$value": "#85888d"
             }
           },
           "dark": {
             "track": {
-              "$type": "color",
-              "$value": "#1e2229",
               "$extensions": {
                 "com.blackbaud.developer.sky-token-scope": "root-has-body"
-              }
+              },
+              "$type": "color",
+              "$value": "#1e2229"
             },
             "thumb": {
-              "$type": "color",
-              "$value": "#51555c",
               "$extensions": {
                 "com.blackbaud.developer.sky-token-scope": "root-has-body"
-              }
+              },
+              "$type": "color",
+              "$value": "#51555c"
             }
           }
         },
         "bb": {
           "dark": {
             "track": {
-              "$type": "color",
-              "$value": "#1C2228",
               "$extensions": {
                 "com.blackbaud.developer.sky-token-scope": "root-has-body"
-              }
+              },
+              "$type": "color",
+              "$value": "#1C2228"
             },
             "thumb": {
-              "$type": "color",
-              "$value": "#51555c",
               "$extensions": {
                 "com.blackbaud.developer.sky-token-scope": "root-has-body"
-              }
+              },
+              "$type": "color",
+              "$value": "#51555c"
             }
           }
         }

--- a/src/tokens/color/base-dark.json
+++ b/src/tokens/color/base-dark.json
@@ -97,7 +97,7 @@
       },
       "blocking": {
         "$type": "color",
-        "$value": "{bb.color.rgba.black.70}"
+        "$value": "{bb.color.rgba.steel-fusion.1100.70}"
       },
       "text_highlight": {
         "$type": "color",
@@ -1064,18 +1064,18 @@
     },
     "scrollbar": {
       "track": {
-        "$type": "color",
-        "$value": "{bb.color.scrollbar.base.dark.track}",
         "$extensions": {
           "com.blackbaud.developer.sky-token-scope": "root-has-body"
-        }
+        },
+        "$type": "color",
+        "$value": "{bb.color.scrollbar.base.dark.track}"
       },
       "thumb": {
-        "$type": "color",
-        "$value": "{bb.color.scrollbar.base.dark.thumb}",
         "$extensions": {
           "com.blackbaud.developer.sky-token-scope": "root-has-body"
-        }
+        },
+        "$type": "color",
+        "$value": "{bb.color.scrollbar.base.dark.thumb}"
       }
     }
   },

--- a/src/tokens/color/bb-dark.json
+++ b/src/tokens/color/bb-dark.json
@@ -93,7 +93,7 @@
       },
       "blocking": {
         "$type": "color",
-        "$value": "{bb.color.rgba.black.70}"
+        "$value": "{bb.color.rgba.steel-fusion.1100.70}"
       },
       "text_highlight": {
         "$type": "color",
@@ -838,18 +838,18 @@
     },
     "scrollbar": {
       "track": {
-        "$type": "color",
-        "$value": "{bb.color.scrollbar.bb.dark.track}",
         "$extensions": {
           "com.blackbaud.developer.sky-token-scope": "root-has-body"
-        }
+        },
+        "$type": "color",
+        "$value": "{bb.color.scrollbar.bb.dark.track}"
       },
       "thumb": {
-        "$type": "color",
-        "$value": "{bb.color.scrollbar.bb.dark.thumb}",
         "$extensions": {
           "com.blackbaud.developer.sky-token-scope": "root-has-body"
-        }
+        },
+        "$type": "color",
+        "$value": "{bb.color.scrollbar.bb.dark.thumb}"
       }
     }
   },


### PR DESCRIPTION
:cherries: Cherry picked from #380 [fix: update blocking wait background in dark mode](https://github.com/blackbaud/skyux-design-tokens/pull/380)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated the dark-mode blocking background to use a translucent steel-fusion color.
- Added the `bb.color.rgba.steel-fusion.1100.70` token.
- Updated token metadata ordering and token set order.

The `.coderabbit.yaml` file from the CodeRabbit repository in ADO was used: https://dev.azure.com/blackbaud/Products/_git/coderabbit

<!-- end of auto-generated comment: release notes by coderabbit.ai -->