### PR TITLE
feat: add underline styling for dark mode links (#397)

### DIFF
--- a/plugins/__snapshots__/build-style-dictionary-plugin.spec.mts.snap
+++ b/plugins/__snapshots__/build-style-dictionary-plugin.spec.mts.snap
@@ -1721,6 +1721,8 @@ exports[`build styles > should generate the correct base, blackbaud, and modern 
   --sky-size-picker_btn: var(--bb-size-fluid-200);
   --sky-size-progress_step: var(--bb-size-fluid-75);
   --sky-size-switch: var(--bb-size-fluid-125);
+  --sky-size-text_underline-offset: var(--bb-size-fluid-12);
+  --sky-size-text_underline-thickness: var(--bb-size-fluid-6);
   --sky-size-thumbnail-l: var(--bb-size-fixed-600);
   --sky-size-width-modal-l: var(--bb-size-fixed-6000);
   --sky-size-width-modal-m: var(--bb-size-fixed-4000);

--- a/src/tokens/$themes.json
+++ b/src/tokens/$themes.json
@@ -1301,6 +1301,7 @@
     "selectedTokenSets": {
       "base-blackbaud": "enabled"
     },
-    "group": "Base"
+    "group": "Base",
+    "$figmaVariableReferences": {}
   }
 ]

--- a/src/tokens/layout/base-productive.json
+++ b/src/tokens/layout/base-productive.json
@@ -585,6 +585,16 @@
           "$value": "{bb.size.fixed.6000}"
         }
       }
+    },
+    "text_underline": {
+      "offset": {
+        "$type": "sizing",
+        "$value": "{bb.size.fluid.12}"
+      },
+      "thickness": {
+        "$type": "sizing",
+        "$value": "{bb.size.fluid.6}"
+      }
     }
   },
   "type": {


### PR DESCRIPTION
:cherries: Cherry picked from #397 [feat: add underline styling for dark mode links](https://github.com/blackbaud/skyux-design-tokens/pull/397)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds dark mode underline styling tokens for links.

- Adds `size.text_underline.offset` and `size.text_underline.thickness`.
- Adds `$figmaVariableReferences` to the `Tokens` theme object.
- Uses `.coderabbit.yaml` from the CodeRabbit repository in ADO: https://dev.azure.com/blackbaud/Products/_git/coderabbit

<!-- end of auto-generated comment: release notes by coderabbit.ai -->