### PR TITLE
chore: changelog for 6.4.0 (#399) 🍒

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 
 ### Features
 
+## [6.4.0](https://github.com/blackbaud/skyux-design-tokens/compare/6.3.1...6.4.0) (2026-08-21)
+
+
+### Features
+
+* add underline styling for dark mode links ([#397](https://github.com/blackbaud/skyux-design-tokens/issues/397)) ([de51fab](https://github.com/blackbaud/skyux-design-tokens/commit/de51fab90ac76e62e6b1de2ed3125d06326a6e08))
+* prominent header and content tokens ([#398](https://github.com/blackbaud/skyux-design-tokens/issues/398)) ([47c6f4b](https://github.com/blackbaud/skyux-design-tokens/commit/47c6f4b3766e5cf4a11365aa793d21ecef176a09))
+
 * add tokens for container overlay border styles ([#384](https://github.com/blackbaud/skyux-design-tokens/issues/384)) ([#386](https://github.com/blackbaud/skyux-design-tokens/issues/386)) ([deaf1cd](https://github.com/blackbaud/skyux-design-tokens/commit/deaf1cd5988cd83baed33302659c589491245e0a))
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,5 @@
 # Changelog
 
-## [7.0.0-alpha.3](https://github.com/blackbaud/skyux-design-tokens/compare/7.0.0-alpha.2...7.0.0-alpha.3) (2026-08-20)
-
-
-### Features
-
 ## [6.4.0](https://github.com/blackbaud/skyux-design-tokens/compare/6.3.1...6.4.0) (2026-08-21)
 
 
@@ -12,6 +7,11 @@
 
 * add underline styling for dark mode links ([#397](https://github.com/blackbaud/skyux-design-tokens/issues/397)) ([de51fab](https://github.com/blackbaud/skyux-design-tokens/commit/de51fab90ac76e62e6b1de2ed3125d06326a6e08))
 * prominent header and content tokens ([#398](https://github.com/blackbaud/skyux-design-tokens/issues/398)) ([47c6f4b](https://github.com/blackbaud/skyux-design-tokens/commit/47c6f4b3766e5cf4a11365aa793d21ecef176a09))
+
+## [7.0.0-alpha.3](https://github.com/blackbaud/skyux-design-tokens/compare/7.0.0-alpha.2...7.0.0-alpha.3) (2026-08-20)
+
+
+### Features
 
 * add tokens for container overlay border styles ([#384](https://github.com/blackbaud/skyux-design-tokens/issues/384)) ([#386](https://github.com/blackbaud/skyux-design-tokens/issues/386)) ([deaf1cd](https://github.com/blackbaud/skyux-design-tokens/commit/deaf1cd5988cd83baed33302659c589491245e0a))
 


### PR DESCRIPTION
:cherries: Cherry picked from #399 [chore: release 6.4.0](https://github.com/blackbaud/skyux-design-tokens/pull/399)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added the `6.4.0` changelog entry dated `2026-08-21`.
- Documented underline styling for dark-mode links.
- Documented prominent header and content tokens.
- Positioned the `7.0.0-alpha.3` entry after `6.4.0`.

The `.coderabbit.yaml` file from the CodeRabbit repository in ADO was used: https://dev.azure.com/blackbaud/Products/_git/coderabbit
<!-- end of auto-generated comment: release notes by coderabbit.ai -->