### PR TITLE
fix: on_prom button colors

### DIFF
--- a/plugins/__snapshots__/build-style-dictionary-plugin.spec.mts.snap
+++ b/plugins/__snapshots__/build-style-dictionary-plugin.spec.mts.snap
@@ -529,6 +529,7 @@ exports[`build styles > should generate the correct base, blackbaud, and modern 
   --sky-color-background-action-tertiary-hover: var(--bb-color-blue-50);
   --sky-color-background-action-tertiary-on_prominent-active: var(--bb-color-slate-600);
   --sky-color-background-action-tertiary-on_prominent-base: var(--bb-color-transparent);
+  --sky-color-background-action-tertiary-on_prominent-disabled: var(--bb-color-gray-700);
   --sky-color-background-action-tertiary-on_prominent-focus: var(--bb-color-transparent);
   --sky-color-background-action-tertiary-on_prominent-hover: var(--bb-color-slate-700);
   --sky-color-background-blocking: var(--bb-color-rgba-white-70);
@@ -601,10 +602,11 @@ exports[`build styles > should generate the correct base, blackbaud, and modern 
   --sky-color-border-action-tertiary-base: var(--bb-color-transparent);
   --sky-color-border-action-tertiary-focus: var(--bb-color-blue-600);
   --sky-color-border-action-tertiary-hover: var(--bb-color-blue-600);
-  --sky-color-border-action-tertiary-on_prominent-active: var(--bb-color-slate-300);
+  --sky-color-border-action-tertiary-on_prominent-active: var(--bb-color-blue-300);
   --sky-color-border-action-tertiary-on_prominent-base: var(--bb-color-transparent);
-  --sky-color-border-action-tertiary-on_prominent-focus: var(--bb-color-slate-300);
-  --sky-color-border-action-tertiary-on_prominent-hover: var(--bb-color-slate-300);
+  --sky-color-border-action-tertiary-on_prominent-disabled: var(--bb-color-gray-800);
+  --sky-color-border-action-tertiary-on_prominent-focus: var(--bb-color-blue-300);
+  --sky-color-border-action-tertiary-on_prominent-hover: var(--bb-color-blue-300);
   --sky-color-border-column_divider: var(--bb-color-blue-600);
   --sky-color-border-container-base: var(--bb-color-gray-200);
   --sky-color-border-container-header-prominent: var(--bb-color-slate-500);
@@ -741,7 +743,6 @@ exports[`build styles > should generate the correct base, blackbaud, and modern 
   --sky-color-background-action-primary-disabled: var(--sky-color-background-disabled);
   --sky-color-background-action-secondary-disabled: var(--sky-color-background-disabled);
   --sky-color-background-action-tertiary-disabled: var(--sky-color-background-disabled);
-  --sky-color-background-action-tertiary-on_prominent-disabled: var(--sky-color-background-disabled);
   --sky-color-background-input-disabled: var(--sky-color-background-disabled);
   --sky-color-background-nav-disabled: var(--sky-color-background-disabled);
   --sky-color-background-row-disabled: var(--sky-color-background-disabled);
@@ -753,7 +754,6 @@ exports[`build styles > should generate the correct base, blackbaud, and modern 
   --sky-color-border-action-primary-disabled: var(--sky-color-border-disabled);
   --sky-color-border-action-secondary-disabled: var(--sky-color-border-disabled);
   --sky-color-border-action-tertiary-disabled: var(--sky-color-border-disabled);
-  --sky-color-border-action-tertiary-on_prominent-disabled: var(--sky-color-border-disabled);
   --sky-color-border-input-disabled: var(--sky-color-border-disabled);
   --sky-color-border-nav-disabled: var(--sky-color-border-disabled);
   --sky-color-border-switch-disabled: var(--sky-color-border-disabled);
@@ -905,10 +905,10 @@ exports[`build styles > should generate the correct base, blackbaud, and modern 
   --sky-color-border-action-tertiary-base: var(--bb-color-transparent);
   --sky-color-border-action-tertiary-focus: var(--bb-color-sky-600);
   --sky-color-border-action-tertiary-hover: var(--bb-color-sky-600);
-  --sky-color-border-action-tertiary-on_prominent-active: var(--bb-color-slate-300);
+  --sky-color-border-action-tertiary-on_prominent-active: var(--bb-color-blue-300);
   --sky-color-border-action-tertiary-on_prominent-base: var(--bb-color-transparent);
-  --sky-color-border-action-tertiary-on_prominent-focus: var(--bb-color-slate-300);
-  --sky-color-border-action-tertiary-on_prominent-hover: var(--bb-color-slate-300);
+  --sky-color-border-action-tertiary-on_prominent-focus: var(--bb-color-blue-300);
+  --sky-color-border-action-tertiary-on_prominent-hover: var(--bb-color-blue-300);
   --sky-color-border-column_divider: var(--bb-color-blue-400);
   --sky-color-border-container-base: var(--bb-color-blue-900);
   --sky-color-border-container-header-prominent: var(--bb-color-slate-500);
@@ -2532,10 +2532,10 @@ exports[`build styles > should generate the correct base, blackbaud, and modern 
   --sky-color-border-action-tertiary-disabled: var(--bb-color-gray-800);
   --sky-color-border-action-tertiary-focus: var(--bb-color-oklch-blue-375);
   --sky-color-border-action-tertiary-hover: var(--bb-color-oklch-blue-375);
-  --sky-color-border-action-tertiary-on_prominent-active: var(--bb-color-slate-300);
+  --sky-color-border-action-tertiary-on_prominent-active: var(--bb-color-blue-300);
   --sky-color-border-action-tertiary-on_prominent-base: var(--bb-color-transparent);
-  --sky-color-border-action-tertiary-on_prominent-focus: var(--bb-color-slate-300);
-  --sky-color-border-action-tertiary-on_prominent-hover: var(--bb-color-slate-300);
+  --sky-color-border-action-tertiary-on_prominent-focus: var(--bb-color-blue-300);
+  --sky-color-border-action-tertiary-on_prominent-hover: var(--bb-color-blue-300);
   --sky-color-border-column_divider: var(--bb-color-blue-400);
   --sky-color-border-container-base: var(--bb-color-steel-fusion-800);
   --sky-color-border-container-header-prominent: var(--bb-color-slate-500);

--- a/src/tokens/color/base-dark.json
+++ b/src/tokens/color/base-dark.json
@@ -598,15 +598,15 @@
             },
             "hover": {
               "$type": "color",
-              "$value": "{bb.color.slate.300}"
+              "$value": "{bb.color.blue.300}"
             },
             "active": {
               "$type": "color",
-              "$value": "{bb.color.slate.300}"
+              "$value": "{bb.color.blue.300}"
             },
             "focus": {
               "$type": "color",
-              "$value": "{bb.color.slate.300}"
+              "$value": "{bb.color.blue.300}"
             },
             "disabled": {
               "$type": "color",

--- a/src/tokens/color/base-light.json
+++ b/src/tokens/color/base-light.json
@@ -204,7 +204,7 @@
             },
             "disabled": {
               "$type": "color",
-              "$value": "{color.background.disabled}"
+              "$value": "{bb.color.gray.700}"
             }
           }
         },
@@ -598,19 +598,19 @@
             },
             "hover": {
               "$type": "color",
-              "$value": "{bb.color.slate.300}"
+              "$value": "{bb.color.blue.300}"
             },
             "active": {
               "$type": "color",
-              "$value": "{bb.color.slate.300}"
+              "$value": "{bb.color.blue.300}"
             },
             "focus": {
               "$type": "color",
-              "$value": "{bb.color.slate.300}"
+              "$value": "{bb.color.blue.300}"
             },
             "disabled": {
               "$type": "color",
-              "$value": "{color.border.disabled}"
+              "$value": "{bb.color.gray.800}"
             }
           }
         },

--- a/src/tokens/color/bb-dark.json
+++ b/src/tokens/color/bb-dark.json
@@ -590,15 +590,15 @@
             },
             "hover": {
               "$type": "color",
-              "$value": "{bb.color.slate.300}"
+              "$value": "{bb.color.blue.300}"
             },
             "active": {
               "$type": "color",
-              "$value": "{bb.color.slate.300}"
+              "$value": "{bb.color.blue.300}"
             },
             "focus": {
               "$type": "color",
-              "$value": "{bb.color.slate.300}"
+              "$value": "{bb.color.blue.300}"
             },
             "disabled": {
               "$type": "color",


### PR DESCRIPTION
Fixed border colors to use blue colors instead of slate.
Updated light mode disabled colors to follow dark mode pattern

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated `on_prom` color tokens.

- Changed hover, active, and focus borders from `slate.300` to `blue.300`.
- Updated light-mode disabled background and border colors to match the dark-mode pattern.
- Updated the related build style dictionary snapshot.
- Updated package metadata, changelog entries, and token configuration tests.

The `.coderabbit.yaml` file from the CodeRabbit repository in ADO is used: https://dev.azure.com/blackbaud/Products/_git/coderabbit
<!-- end of auto-generated comment: release notes by coderabbit.ai -->