### PR TITLE
fix: update on_prom icon colors to include disabled state (#415)

### DIFF
--- a/plugins/__snapshots__/build-style-dictionary-plugin.spec.mts.snap
+++ b/plugins/__snapshots__/build-style-dictionary-plugin.spec.mts.snap
@@ -675,7 +675,8 @@ exports[`build styles > should generate the correct base, blackbaud, and modern 
   --sky-color-icon-info: var(--bb-color-blue-600);
   --sky-color-icon-input-action: var(--bb-color-gray-600);
   --sky-color-icon-inverse: var(--bb-color-white);
-  --sky-color-icon-on_prominent: var(--bb-color-white);
+  --sky-color-icon-on_prominent-base: var(--bb-color-white);
+  --sky-color-icon-on_prominent-disabled: var(--bb-color-gray-600);
   --sky-color-icon-selected: var(--bb-color-blue-600);
   --sky-color-icon-success: var(--bb-color-green-600);
   --sky-color-icon-warning: var(--bb-color-yellow-400);
@@ -977,7 +978,8 @@ exports[`build styles > should generate the correct base, blackbaud, and modern 
   --sky-color-icon-info: var(--bb-color-blue-600);
   --sky-color-icon-input-action: var(--bb-color-sky-600);
   --sky-color-icon-inverse: var(--bb-color-gray-1100);
-  --sky-color-icon-on_prominent: var(--bb-color-white);
+  --sky-color-icon-on_prominent-base: var(--bb-color-white);
+  --sky-color-icon-on_prominent-disabled: var(--bb-color-gray-600);
   --sky-color-icon-selected: var(--bb-color-blue-600);
   --sky-color-icon-success: var(--bb-color-green-700);
   --sky-color-icon-warning: var(--bb-color-yellow-600);
@@ -2602,7 +2604,8 @@ exports[`build styles > should generate the correct base, blackbaud, and modern 
   --sky-color-icon-info: var(--bb-color-blue-600);
   --sky-color-icon-input-action: var(--bb-color-oklch-blue-375);
   --sky-color-icon-inverse: var(--bb-color-black);
-  --sky-color-icon-on_prominent: var(--bb-color-white);
+  --sky-color-icon-on_prominent-base: var(--bb-color-white);
+  --sky-color-icon-on_prominent-disabled: var(--bb-color-gray-600);
   --sky-color-icon-selected: var(--bb-color-oklch-blue-375);
   --sky-color-icon-success: var(--bb-color-green-600);
   --sky-color-icon-warning: var(--bb-color-yellow-600);
@@ -2798,7 +2801,8 @@ exports[`build styles > should generate the correct public API styles 1`] = `
   --sky-theme-color-icon-default: var(--sky-color-icon-default);
   --sky-theme-color-icon-info: var(--sky-color-icon-info);
   --sky-theme-color-icon-inverse: var(--sky-color-icon-inverse);
-  --sky-theme-color-icon-on_prominent: var(--sky-color-icon-on_prominent);
+  --sky-theme-color-icon-on_prominent-base: var(--sky-color-icon-on_prominent-base);
+  --sky-theme-color-icon-on_prominent-disabled: var(--sky-color-icon-on_prominent-disabled);
   --sky-theme-color-icon-success: var(--sky-color-icon-success);
   --sky-theme-color-text-action: var(--sky-color-text-action);
   --sky-theme-color-text-action_contrast: var(--sky-color-text-action_contrast);
@@ -3026,7 +3030,8 @@ exports[`build styles > should generate the correct public API styles 1`] = `
   --sky-theme-color-icon-default: #212327;
   --sky-theme-color-icon-info: #00b4f1;
   --sky-theme-color-icon-inverse: #ffffff;
-  --sky-theme-color-icon-on_prominent: #ffffff;
+  --sky-theme-color-icon-on_prominent-base: #ffffff;
+  --sky-theme-color-icon-on_prominent-disabled: #686c73;
   --sky-theme-color-icon-success: #72bf44;
   --sky-theme-color-text-action: #0974a1;
   --sky-theme-color-text-action_contrast: #0974a1;
@@ -3495,7 +3500,7 @@ em {
   color: var(--sky-theme-color-icon-inverse);
 }
 .sky-theme-color-icon-on_prominent {
-  color: var(--sky-theme-color-icon-on_prominent);
+  color: var(--sky-theme-color-icon-on_prominent-base);
 }
 .sky-theme-color-background-icon_matte-action-soft {
   background-color: var(--sky-theme-color-background-icon_matte-action-soft);

--- a/src/classes/public/colors.json
+++ b/src/classes/public/colors.json
@@ -158,7 +158,7 @@
                   "className": "sky-theme-color-icon-on_prominent",
                   "description": "The color for icons on prominent container headers.",
                   "properties": {
-                    "color": "var(--sky-theme-color-icon-on_prominent)"
+                    "color": "var(--sky-theme-color-icon-on_prominent-base)"
                   },
                   "demoMetadata": {
                     "background": "--sky-theme-color-background-container-header-prominent"

--- a/src/docs/colors.json
+++ b/src/docs/colors.json
@@ -202,10 +202,18 @@
                 },
                 {
                   "name": "Prominent container header icon",
-                  "customProperty": "--sky-theme-color-icon-on_prominent",
+                  "customProperty": "--sky-theme-color-icon-on_prominent-base",
                   "description": "The color for icons on prominent container headers.",
                   "demoMetadata": {
                     "background": "--sky-theme-color-background-container-header-prominent"
+                  }
+                },
+                {
+                  "name": "Disabled prominent container header icon",
+                  "customProperty": "--sky-theme-color-icon-on_prominent-disabled",
+                  "description": "The color for icons in disabled buttons on prominent container headers.",
+                  "demoMetadata": {
+                    "background": "--sky-theme-color-background-action-tertiary-on_prominent-disabled"
                   }
                 }
               ]

--- a/src/tokens/color/base-dark.json
+++ b/src/tokens/color/base-dark.json
@@ -80,8 +80,14 @@
         "$value": "{bb.color.brand.impact_green}"
       },
       "on_prominent": {
-        "$type": "color",
-        "$value": "{bb.color.white}"
+        "base": {
+          "$type": "color",
+          "$value": "{bb.color.white}"
+        },
+        "disabled": {
+          "$type": "color",
+          "$value": "{bb.color.gray.600}"
+        }
       },
       "input": {
         "action": {

--- a/src/tokens/color/base-light.json
+++ b/src/tokens/color/base-light.json
@@ -80,8 +80,14 @@
         "$value": "{bb.color.brand.impact_green}"
       },
       "on_prominent": {
-        "$type": "color",
-        "$value": "{bb.color.white}"
+        "base": {
+          "$type": "color",
+          "$value": "{bb.color.white}"
+        },
+        "disabled": {
+          "$type": "color",
+          "$value": "{bb.color.gray.600}"
+        }
       },
       "input": {
         "action": {

--- a/src/tokens/color/bb-dark.json
+++ b/src/tokens/color/bb-dark.json
@@ -76,8 +76,14 @@
         "$value": "{bb.color.oklch-blue.375}"
       },
       "on_prominent": {
-        "$type": "color",
-        "$value": "{bb.color.white}"
+        "base": {
+          "$type": "color",
+          "$value": "{bb.color.white}"
+        },
+        "disabled": {
+          "$type": "color",
+          "$value": "{bb.color.gray.600}"
+        }
       },
       "input": {
         "action": {

--- a/src/tokens/public/colors.json
+++ b/src/tokens/public/colors.json
@@ -175,8 +175,14 @@
           "$value": "{color.icon.success}"
         },
         "on_prominent": {
-          "$type": "color",
-          "$value": "{color.icon.on_prominent}"
+          "base": {
+            "$type": "color",
+            "$value": "{color.icon.on_prominent.base}"
+          },
+          "disabled": {
+            "$type": "color",
+            "$value": "{color.icon.on_prominent.disabled}"
+          }
         }
       },
       "classify": {

--- a/src/tokens/public/default/colors.json
+++ b/src/tokens/public/default/colors.json
@@ -175,8 +175,14 @@
           "$value": "#72bf44"
         },
         "on_prominent": {
-          "$type": "color",
-          "$value": "#ffffff"
+          "base": {
+            "$type": "color",
+            "$value": "#ffffff"
+          },
+          "disabled": {
+            "$type": "color",
+            "$value": "#686c73"
+          }
         }
       },
       "classify": {


### PR DESCRIPTION
:cherries: Cherry picked from #415 [fix: update on_prom icon colors to include disabled state](https://github.com/blackbaud/skyux-design-tokens/pull/415)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Updated prominent container header icon colors to support `base` and `disabled` states across themes and public color definitions.

The `.coderabbit.yaml` configuration from the [coderabbit repository in ADO](https://dev.azure.com/blackbaud/Products/_git/coderabbit) is used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->