### PR TITLE
fix: update action contrast text color in dark mode (#423)

### DIFF
--- a/plugins/__snapshots__/build-style-dictionary-plugin.spec.mts.snap
+++ b/plugins/__snapshots__/build-style-dictionary-plugin.spec.mts.snap
@@ -1029,7 +1029,7 @@ exports[`build styles > should generate the correct base, blackbaud, and modern 
   --sky-color-illustration-fill-softest: var(--bb-color-gray-900);
   --sky-color-illustration-stroke: var(--bb-color-green-200);
   --sky-color-text-action: var(--bb-color-sky-600);
-  --sky-color-text-action_contrast: var(--bb-color-blue-300);
+  --sky-color-text-action_contrast: var(--bb-color-blue-dark-200);
   --sky-color-text-danger: var(--bb-color-red-400);
   --sky-color-text-deemphasized: var(--bb-color-gray-300);
   --sky-color-text-default: var(--bb-color-gray-25);
@@ -2697,7 +2697,7 @@ exports[`build styles > should generate the correct base, blackbaud, and modern 
   --sky-color-illustration-fill-softest: var(--bb-color-gray-900);
   --sky-color-illustration-stroke: var(--bb-color-green-200);
   --sky-color-text-action: var(--bb-color-blue-dark-375);
-  --sky-color-text-action_contrast: var(--bb-color-blue-dark-300);
+  --sky-color-text-action_contrast: var(--bb-color-blue-dark-200);
   --sky-color-text-danger: var(--bb-color-red-dark-400);
   --sky-color-text-deemphasized: var(--bb-color-steel-gray-400);
   --sky-color-text-default: var(--bb-color-steel-gray-200);

--- a/src/tokens/color/base-dark.json
+++ b/src/tokens/color/base-dark.json
@@ -31,7 +31,7 @@
       },
       "action_contrast": {
         "$type": "color",
-        "$value": "{bb.color.blue.300}"
+        "$value": "{bb.color.blue-dark.200}"
       },
       "on_prominent": {
         "$type": "color",

--- a/src/tokens/color/bb-dark.json
+++ b/src/tokens/color/bb-dark.json
@@ -31,7 +31,7 @@
       },
       "action_contrast": {
         "$type": "color",
-        "$value": "{bb.color.blue-dark.300}"
+        "$value": "{bb.color.blue-dark.200}"
       },
       "on_prominent": {
         "$type": "color",


### PR DESCRIPTION
:cherries: Cherry picked from #423 [fix: update action contrast text color in dark mode](https://github.com/blackbaud/skyux-design-tokens/pull/423)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Updated the dark-mode action contrast text color from `blue-dark.300` to `blue-dark.200`.

This change is a cherry-pick of pull request `#423`.

The `.coderabbit.yaml` file from the CodeRabbit repository in ADO is used: https://dev.azure.com/blackbaud/Products/_git/coderabbit

<!-- end of auto-generated comment: release notes by coderabbit.ai -->