### PR TITLE
feat: generate base/brand/public API combo CSS (#428)

### DIFF
--- a/plugins/build-combo-css-plugin.mts
+++ b/plugins/build-combo-css-plugin.mts
@@ -1,0 +1,44 @@
+import type { Plugin, Rollup } from 'vite';
+
+export interface ComboCssPluginOptions {
+  /**
+   * The bundle-relative fileName to emit, e.g. `bundles/base-blackbaud-public-api-combo.css`.
+   */
+  fileName: string;
+  /**
+   * The bundle-relative fileNames of the CSS assets to concatenate, in order.
+   * Each must already have been emitted by an earlier plugin's `generateBundle` hook.
+   */
+  sourceFileNames: string[];
+}
+
+export function buildComboCssPlugin(options: ComboCssPluginOptions): Plugin {
+  const { fileName, sourceFileNames } = options;
+
+  return {
+    name: 'build-combo-css',
+    generateBundle(_outputOptions, bundle) {
+      const source = sourceFileNames
+        .map((sourceFileName) => {
+          const asset = bundle[sourceFileName] as
+            | Rollup.OutputAsset
+            | undefined;
+
+          if (!asset || asset.type !== 'asset') {
+            throw new Error(
+              `Cannot build combo file "${fileName}": expected "${sourceFileName}" to already be emitted as a CSS asset.`,
+            );
+          }
+
+          return asset.source as string;
+        })
+        .join('\n');
+
+      this.emitFile({
+        type: 'asset',
+        fileName,
+        source,
+      });
+    },
+  };
+}

--- a/plugins/build-combo-css-plugin.spec.mts
+++ b/plugins/build-combo-css-plugin.spec.mts
@@ -1,0 +1,100 @@
+import type { Rollup } from 'vite';
+import { describe, expect, it, vi } from 'vitest';
+import { buildComboCssPlugin } from './build-combo-css-plugin.mts';
+
+function createAsset(source: string): Rollup.OutputAsset {
+  return {
+    type: 'asset',
+    source,
+  } as Rollup.OutputAsset;
+}
+
+function createChunk(): Rollup.OutputChunk {
+  return {
+    type: 'chunk',
+    code: '',
+  } as Rollup.OutputChunk;
+}
+
+describe('build combo css plugin', () => {
+  it('should concatenate the source assets in order and emit the combo file', async () => {
+    const plugin = buildComboCssPlugin({
+      fileName: 'bundles/combo.css',
+      sourceFileNames: ['bundles/a.css', 'bundles/b.css', 'bundles/c.css'],
+    });
+    const emitFileSpy = vi.fn();
+    const bundle: Rollup.OutputBundle = {
+      'bundles/a.css': createAsset('.a {}\n'),
+      'bundles/b.css': createAsset('.b {}\n'),
+      'bundles/c.css': createAsset('.c {}\n'),
+    };
+
+    if (typeof plugin.generateBundle !== 'function') {
+      throw new Error('Expected generateBundle to be a function');
+    }
+    await plugin.generateBundle.call(
+      { emitFile: emitFileSpy } as unknown as Rollup.PluginContext,
+      {} as Rollup.NormalizedOutputOptions,
+      bundle,
+      false,
+    );
+
+    expect(emitFileSpy).toHaveBeenCalledExactlyOnceWith({
+      type: 'asset',
+      fileName: 'bundles/combo.css',
+      source: '.a {}\n\n.b {}\n\n.c {}\n',
+    });
+  });
+
+  it('should throw when a source fileName is missing from the bundle', async () => {
+    const plugin = buildComboCssPlugin({
+      fileName: 'bundles/combo.css',
+      sourceFileNames: ['bundles/a.css', 'bundles/missing.css'],
+    });
+    const bundle: Rollup.OutputBundle = {
+      'bundles/a.css': createAsset('.a {}\n'),
+    };
+
+    const { generateBundle } = plugin;
+    if (typeof generateBundle !== 'function') {
+      throw new Error('Expected generateBundle to be a function');
+    }
+
+    expect(() =>
+      generateBundle.call(
+        { emitFile: vi.fn() } as unknown as Rollup.PluginContext,
+        {} as Rollup.NormalizedOutputOptions,
+        bundle,
+        false,
+      ),
+    ).toThrow(
+      'Cannot build combo file "bundles/combo.css": expected "bundles/missing.css" to already be emitted as a CSS asset.',
+    );
+  });
+
+  it('should throw when a source fileName refers to a chunk instead of an asset', async () => {
+    const plugin = buildComboCssPlugin({
+      fileName: 'bundles/combo.css',
+      sourceFileNames: ['bundles/a.css'],
+    });
+    const bundle: Rollup.OutputBundle = {
+      'bundles/a.css': createChunk(),
+    };
+
+    const { generateBundle } = plugin;
+    if (typeof generateBundle !== 'function') {
+      throw new Error('Expected generateBundle to be a function');
+    }
+
+    expect(() =>
+      generateBundle.call(
+        { emitFile: vi.fn() } as unknown as Rollup.PluginContext,
+        {} as Rollup.NormalizedOutputOptions,
+        bundle,
+        false,
+      ),
+    ).toThrow(
+      'Cannot build combo file "bundles/combo.css": expected "bundles/a.css" to already be emitted as a CSS asset.',
+    );
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import { loadEnv } from 'vite';
 import { defineConfig } from 'vitest/config';
 import { buildStylesPlugin } from './plugins/build-styles-plugin.mjs';
+import { buildComboCssPlugin } from './plugins/build-combo-css-plugin.mts';
 import {
   buildAssetsManifestPlugin,
   buildStyleDictionaryPlugin,
@@ -49,6 +50,18 @@ export default defineConfig(({ mode }) => {
     plugins: [
       buildStylesPlugin(),
       buildStyleDictionaryPlugin(tokenConfig),
+      buildComboCssPlugin({
+        fileName: 'bundles/base_public-api.css',
+        sourceFileNames: ['bundles/base.css', 'bundles/public-api.css'],
+      }),
+      buildComboCssPlugin({
+        fileName: 'bundles/base_blackbaud_public-api.css',
+        sourceFileNames: [
+          'bundles/base.css',
+          'bundles/blackbaud.css',
+          'bundles/public-api.css',
+        ],
+      }),
       buildAssetsManifestPlugin(tokenConfig.projectName),
       preparePackagePlugin(import.meta.dirname),
     ],


### PR DESCRIPTION
:cherries: Cherry picked from #428 [feat: generate base/brand/public API combo CSS](https://github.com/blackbaud/skyux-design-tokens/pull/428)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added `buildComboCssPlugin` to concatenate emitted CSS assets in a defined order.
- Configured combined CSS bundles for base/public API and base/Blackbaud/public API styles.
- Added tests for successful generation and invalid source assets.
- The `.coderabbit.yaml` file from the CodeRabbit repository in ADO is being used: https://dev.azure.com/blackbaud/Products/_git/coderabbit

<!-- end of auto-generated comment: release notes by coderabbit.ai -->