### PR TITLE
feat: add prominent container background (#431)

### DIFF
--- a/plugins/__snapshots__/build-style-dictionary-plugin.spec.mts.snap
+++ b/plugins/__snapshots__/build-style-dictionary-plugin.spec.mts.snap
@@ -581,6 +581,7 @@ exports[`build styles > should generate the correct base, blackbaud, and modern 
   --sky-color-background-container-header-prominent: var(--bb-color-slate-800);
   --sky-color-background-container-info: var(--bb-color-blue-200);
   --sky-color-background-container-menu: var(--bb-color-white);
+  --sky-color-background-container-prominent: var(--bb-color-slate-50);
   --sky-color-background-container-success: var(--bb-color-green-200);
   --sky-color-background-container-tooltip: var(--bb-color-gray-1000);
   --sky-color-background-container-warning: var(--bb-color-yellow-200);
@@ -885,6 +886,7 @@ exports[`build styles > should generate the correct base, blackbaud, and modern 
   --sky-color-background-container-header-prominent: var(--bb-color-slate-800);
   --sky-color-background-container-info: var(--bb-color-blue-800);
   --sky-color-background-container-menu: var(--bb-color-gray-900);
+  --sky-color-background-container-prominent: var(--bb-color-steel-gray-1125);
   --sky-color-background-container-success: var(--bb-color-green-900);
   --sky-color-background-container-tooltip: var(--bb-color-gray-25);
   --sky-color-background-container-warning: var(--bb-color-yellow-800);
@@ -2549,6 +2551,7 @@ exports[`build styles > should generate the correct base, blackbaud, and modern 
   --sky-color-background-container-header-prominent: var(--bb-color-slate-800);
   --sky-color-background-container-info: var(--bb-color-blue-dark-400);
   --sky-color-background-container-menu: var(--bb-color-steel-gray-900);
+  --sky-color-background-container-prominent: var(--bb-color-steel-gray-1125);
   --sky-color-background-container-success: var(--bb-color-green-dark-400);
   --sky-color-background-container-warning: var(--bb-color-yellow-dark-400);
   --sky-color-background-disabled: var(--bb-color-gray-700);
@@ -2846,6 +2849,7 @@ exports[`build styles > should generate the correct public API styles 1`] = `
   --sky-theme-color-background-container-dimmed: var(--sky-color-background-container-dimmed);
   --sky-theme-color-background-container-header-prominent: var(--sky-color-background-container-header-prominent);
   --sky-theme-color-background-container-info: var(--sky-color-background-container-info);
+  --sky-theme-color-background-container-prominent: var(--sky-color-background-container-prominent);
   --sky-theme-color-background-container-success: var(--sky-color-background-container-success);
   --sky-theme-color-background-container-warning: var(--sky-color-background-container-warning);
   --sky-theme-color-background-disabled: var(--sky-color-background-disabled);
@@ -3075,6 +3079,7 @@ exports[`build styles > should generate the correct public API styles 1`] = `
   --sky-theme-color-background-container-dimmed: #eeeeef;
   --sky-theme-color-background-container-header-prominent: #32435e;
   --sky-theme-color-background-container-info: #81d4f7;
+  --sky-theme-color-background-container-prominent: #f6f8fa;
   --sky-theme-color-background-container-success: #b7da9b;
   --sky-theme-color-background-container-warning: #ffd597;
   --sky-theme-color-background-disabled: #cdcfd2;
@@ -3554,6 +3559,9 @@ em {
 }
 .sky-theme-color-background-container-backdrop {
   background-color: var(--sky-theme-color-background-container-backdrop);
+}
+.sky-theme-color-background-container-prominent {
+  background-color: var(--sky-theme-color-background-container-prominent);
 }
 .sky-theme-color-background-container-header-prominent {
   background-color: var(--sky-theme-color-background-container-header-prominent);

--- a/src/classes/public/colors.json
+++ b/src/classes/public/colors.json
@@ -48,6 +48,14 @@
                   }
                 },
                 {
+                  "name": "Prominent container background",
+                  "className": "sky-theme-color-background-container-prominent",
+                  "description": "The background color for containers of tools that work alongside the main page content.",
+                  "properties": {
+                    "background-color": "var(--sky-theme-color-background-container-prominent)"
+                  }
+                },
+                {
                   "name": "Prominent container header background",
                   "className": "sky-theme-color-background-container-header-prominent",
                   "description": "The background color for headers of containers of tools that work alongside the main page content.",

--- a/src/docs/colors.json
+++ b/src/docs/colors.json
@@ -46,6 +46,11 @@
                   "description": "The background color for containers behind a canvas, WYSIWYG editor, or preview."
                 },
                 {
+                  "name": "Prominent container background",
+                  "customProperty": "--sky-theme-color-background-container-prominent",
+                  "description": "The background color for containers of tools that work alongside the main page content."
+                },
+                {
                   "name": "Prominent container header background",
                   "customProperty": "--sky-theme-color-background-container-header-prominent",
                   "description": "The background color for headers of containers of tools that work alongside the main page content."

--- a/src/tokens/color/base-dark.json
+++ b/src/tokens/color/base-dark.json
@@ -318,6 +318,10 @@
           "$type": "color",
           "$value": "{bb.color.gray.25}"
         },
+        "prominent": {
+          "$type": "color",
+          "$value": "{bb.color.steel-gray.1125}"
+        },
         "header": {
           "prominent": {
             "$type": "color",

--- a/src/tokens/color/base-light.json
+++ b/src/tokens/color/base-light.json
@@ -318,6 +318,10 @@
           "$type": "color",
           "$value": "{bb.color.gray.1000}"
         },
+        "prominent": {
+          "$type": "color",
+          "$value": "{bb.color.slate.50}"
+        },
         "header": {
           "prominent": {
             "$type": "color",

--- a/src/tokens/color/bb-dark.json
+++ b/src/tokens/color/bb-dark.json
@@ -310,6 +310,10 @@
           "$type": "color",
           "$value": "{bb.color.steel-gray.1000}"
         },
+        "prominent": {
+          "$type": "color",
+          "$value": "{bb.color.steel-gray.1125}"
+        },
         "header": {
           "prominent": {
             "$type": "color",

--- a/src/tokens/public/colors.json
+++ b/src/tokens/public/colors.json
@@ -35,6 +35,10 @@
             "$type": "color",
             "$value": "{color.background.container.warning}"
           },
+          "prominent": {
+            "$type": "color",
+            "$value": "{color.background.container.prominent}"
+          },
           "header": {
             "prominent": {
               "$type": "color",

--- a/src/tokens/public/default/colors.json
+++ b/src/tokens/public/default/colors.json
@@ -35,6 +35,10 @@
             "$type": "color",
             "$value": "#ffd597"
           },
+          "prominent": {
+            "$type": "color",
+            "$value": "#f6f8fa"
+          },
           "header": {
             "prominent": {
               "$type": "color",


### PR DESCRIPTION
:cherries: Cherry picked from #431 [feat: add prominent container background](https://github.com/blackbaud/skyux-design-tokens/pull/431)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds the prominent container background color token for light and dark themes. Updates public color definitions and documentation with the `--sky-theme-color-background-container-prominent` mapping.

The `.coderabbit.yaml` file from the CodeRabbit repository in ADO is used: https://dev.azure.com/blackbaud/Products/_git/coderabbit

<!-- end of auto-generated comment: release notes by coderabbit.ai -->