### PR TITLE
fix: remove light mode selector from light mode styles (#436)

### DIFF
--- a/plugins/__snapshots__/build-style-dictionary-plugin.spec.mts.snap
+++ b/plugins/__snapshots__/build-style-dictionary-plugin.spec.mts.snap
@@ -542,7 +542,7 @@ exports[`build styles > should generate the correct base, blackbaud, and modern 
   --bb-color-scrollbar-bb-dark-thumb: #51555c;
   --bb-color-scrollbar-bb-dark-track: #1c2228;
 }
-.sky-theme-modern.sky-theme-brand-base.sky-theme-mode-light {
+.sky-theme-modern.sky-theme-brand-base:not(.sky-theme-mode-dark) {
   --sky-brand-name: var(--bb-brand-name);
   --sky-color-background-action-accent-active: var(--bb-color-blue-100);
   --sky-color-background-action-accent-base: var(--bb-color-white);
@@ -843,7 +843,7 @@ exports[`build styles > should generate the correct base, blackbaud, and modern 
   --sky-elevation-overlay-simple-100: var(--bb-shadow-gray-simple-400);
   --sky-elevation-raised-100: var(--bb-shadow-gray-100);
 }
-:root:has(body.sky-theme-modern.sky-theme-brand-base.sky-theme-mode-light) {
+:root:has(body.sky-theme-modern.sky-theme-brand-base:not(.sky-theme-mode-dark)) {
   --sky-color-scrollbar-thumb: var(--bb-color-scrollbar-base-light-thumb);
   --sky-color-scrollbar-track: var(--bb-color-scrollbar-base-light-track);
 }
@@ -2435,7 +2435,7 @@ exports[`build styles > should generate the correct base, blackbaud, and modern 
   --bb-color-scrollbar-bb-dark-thumb: #51555c;
   --bb-color-scrollbar-bb-dark-track: #1c2228;
 }
-.sky-theme-modern.sky-theme-brand-base.sky-theme-brand-blackbaud.sky-theme-mode-light {
+.sky-theme-modern.sky-theme-brand-base.sky-theme-brand-blackbaud:not(.sky-theme-mode-dark) {
   --sky-brand-name: var(--bb-brand-name);
   --sky-color-background-action-accent-base: var(--bb-color-blue-25);
   --sky-color-background-container-backdrop: var(--bb-color-slate-200);

--- a/src/tokens/token-config.mts
+++ b/src/tokens/token-config.mts
@@ -10,7 +10,7 @@ export const tokenConfig: TokenConfig = {
       referenceTokens: [
         {
           name: 'base-light',
-          selector: '.sky-theme-mode-light',
+          selector: ':not(.sky-theme-mode-dark)',
           path: 'color/base-light.json',
         },
         {
@@ -71,7 +71,7 @@ export const tokenConfig: TokenConfig = {
       referenceTokens: [
         {
           name: 'bb-light',
-          selector: '.sky-theme-mode-light',
+          selector: ':not(.sky-theme-mode-dark)',
           path: 'color/bb-light.json',
         },
         {

--- a/src/tokens/token-config.spec.mts
+++ b/src/tokens/token-config.spec.mts
@@ -12,7 +12,7 @@ test('should have token sets in the correct format', () => {
   /* eslint-disable @typescript-eslint/no-non-null-assertion */
   expect({
     name: 'base-light',
-    selector: '.sky-theme-mode-light',
+    selector: ':not(.sky-theme-mode-dark)',
     path: 'color/base-light.json',
   }).toBeOneOf(tokenSets[0].referenceTokens!);
   expect({
@@ -32,7 +32,7 @@ test('should have token sets in the correct format', () => {
   expect(tokenSets[1].path).toEqual('base-blackbaud.json');
   expect({
     name: 'bb-light',
-    selector: '.sky-theme-mode-light',
+    selector: ':not(.sky-theme-mode-dark)',
     path: 'color/bb-light.json',
   }).toBeOneOf(tokenSets[1].referenceTokens!);
   expect({


### PR DESCRIPTION
:cherries: Cherry picked from #436 [fix: remove light mode selector from light mode styles](https://github.com/blackbaud/skyux-design-tokens/pull/436)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Removed the `.sky-theme-mode-light` selector from `base-light` and `bb-light` styles.
- Light-theme styles now apply to elements that do not use `.sky-theme-mode-dark`.
- Updated the related token configuration tests.

The `.coderabbit.yaml` file from the CodeRabbit repository in ADO is being used: https://dev.azure.com/blackbaud/Products/_git/coderabbit

<!-- end of auto-generated comment: release notes by coderabbit.ai -->