### PR TITLE
feat: add icon color on_status_bg (#444)

### DIFF
--- a/plugins/__snapshots__/build-style-dictionary-plugin.spec.mts.snap
+++ b/plugins/__snapshots__/build-style-dictionary-plugin.spec.mts.snap
@@ -720,6 +720,7 @@ exports[`build styles > should generate the correct base, blackbaud, and modern 
   --sky-color-icon-on_prominent-base: var(--bb-color-white);
   --sky-color-icon-on_prominent-disabled: var(--bb-color-gray-600);
   --sky-color-icon-on_status: var(--bb-color-white);
+  --sky-color-icon-on_status_bg: var(--bb-color-gray-1000);
   --sky-color-icon-selected: var(--bb-color-blue-600);
   --sky-color-icon-success: var(--bb-color-green-600);
   --sky-color-icon-warning: var(--bb-color-yellow-400);
@@ -1026,6 +1027,7 @@ exports[`build styles > should generate the correct base, blackbaud, and modern 
   --sky-color-icon-on_prominent-base: var(--bb-color-white);
   --sky-color-icon-on_prominent-disabled: var(--bb-color-gray-600);
   --sky-color-icon-on_status: var(--bb-color-white);
+  --sky-color-icon-on_status_bg: var(--bb-color-gray-1000);
   --sky-color-icon-selected: var(--bb-color-blue-600);
   --sky-color-icon-success: var(--bb-color-green-700);
   --sky-color-icon-warning: var(--bb-color-yellow-600);
@@ -2697,6 +2699,7 @@ exports[`build styles > should generate the correct base, blackbaud, and modern 
   --sky-color-icon-on_prominent-base: var(--bb-color-white);
   --sky-color-icon-on_prominent-disabled: var(--bb-color-gray-600);
   --sky-color-icon-on_status: var(--bb-color-white);
+  --sky-color-icon-on_status_bg: var(--bb-color-steel-gray-1100);
   --sky-color-icon-selected: var(--bb-color-blue-dark-300);
   --sky-color-icon-success: var(--bb-color-green-dark-400);
   --sky-color-icon-warning: var(--bb-color-yellow-dark-400);

--- a/src/tokens/color/base-dark.json
+++ b/src/tokens/color/base-dark.json
@@ -97,6 +97,10 @@
         "$type": "color",
         "$value": "{bb.color.white}"
       },
+      "on_status_bg": {
+        "$type": "color",
+        "$value": "{bb.color.gray.1000}"
+      },
       "input": {
         "action": {
           "$type": "color",

--- a/src/tokens/color/base-light.json
+++ b/src/tokens/color/base-light.json
@@ -97,6 +97,10 @@
         "$type": "color",
         "$value": "{bb.color.white}"
       },
+      "on_status_bg": {
+        "$type": "color",
+        "$value": "{bb.color.gray.1000}"
+      },
       "input": {
         "action": {
           "$type": "color",

--- a/src/tokens/color/bb-dark.json
+++ b/src/tokens/color/bb-dark.json
@@ -99,6 +99,10 @@
         "$type": "color",
         "$value": "{bb.color.white}"
       },
+      "on_status_bg": {
+        "$type": "color",
+        "$value": "{bb.color.steel-gray.1100}"
+      },
       "input": {
         "action": {
           "$type": "color",


### PR DESCRIPTION
:cherries: Cherry picked from #444 [feat: add icon color on_status_bg](https://github.com/blackbaud/skyux-design-tokens/pull/444)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Added the `color.icon.on_status_bg` token to the dark and light color themes.

- Base themes use `{bb.color.gray.1000}`.
- Blackbaud dark theme uses `{bb.color.steel-gray.1100}`.
- All tokens use type `color`.

The `.coderabbit.yaml` file from the CodeRabbit repository in ADO was used: https://dev.azure.com/blackbaud/Products/_git/coderabbit

<!-- end of auto-generated comment: release notes by coderabbit.ai -->